### PR TITLE
fix: harden docstring schema parsing and tool result formatting

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -888,7 +888,9 @@ class Agentlys(AgentlysBase):
                         + f"\n... ({len(formatted_content)} characters)"
                     )
         elif isinstance(content, dict):
-            content_dump = json.dumps(content)
+            # default=str: tool results routinely carry values json doesn't
+            # know (Decimal, datetime, UUID, ...); stringify instead of crashing
+            content_dump = json.dumps(content, default=str)
             if len(content_dump) > OUTPUT_SIZE_LIMIT:
                 formatted_content = (
                     content_dump[:OUTPUT_SIZE_LIMIT]
@@ -943,6 +945,37 @@ class Agentlys(AgentlysBase):
             )
 
         return Message(name=function_name, role="function", parts=[part])
+
+    def _format_callback_message_safe(
+        self, function_name, function_call_id, content, image
+    ):
+        """Format a tool result under the same error boundary as tool execution.
+
+        Formatting runs after _execute_single_tool's try/except, so a return
+        value that can't be formatted must become an error function_result the
+        model can react to — not an exception that kills the whole turn.
+        """
+        try:
+            return self._format_callback_message(
+                function_name=function_name,
+                function_call_id=function_call_id,
+                content=content,
+                image=image,
+            )
+        except StopLoopException:
+            raise
+        except Exception as e:
+            return Message(
+                name=function_name,
+                role="function",
+                parts=[
+                    MessagePart(
+                        type="function_result",
+                        content=self._format_exception(e),
+                        function_call_id=function_call_id,
+                    )
+                ],
+            )
 
     def _format_exception(self, e):
         # We clean the traceback to remove frames from __init__.py, plus the
@@ -1130,7 +1163,7 @@ class Agentlys(AgentlysBase):
                 continue
 
             function_call_id, function_name, content, image = result
-            formatted_msg = self._format_callback_message(
+            formatted_msg = self._format_callback_message_safe(
                 function_name=function_name,
                 function_call_id=function_call_id,
                 content=content,
@@ -1194,7 +1227,7 @@ class Agentlys(AgentlysBase):
                     continue
 
                 function_call_id, function_name, content, image = result
-                formatted_msg = self._format_callback_message(
+                formatted_msg = self._format_callback_message_safe(
                     function_name=function_name,
                     function_call_id=function_call_id,
                     content=content,

--- a/src/agentlys/utils.py
+++ b/src/agentlys/utils.py
@@ -61,6 +61,25 @@ def limit_data_size(
     return result_data
 
 
+def _dump_rows_csv(rows: list[dict]) -> str:
+    # Use the union of keys across rows: heterogeneous dicts are a routine
+    # shape for query results, and DictWriter raises on keys missing from
+    # fieldnames.
+    header = []
+    seen_keys = set()
+    for row in rows:
+        for key in row:
+            if key not in seen_keys:
+                seen_keys.add(key)
+                header.append(key)
+    with StringIO() as output:
+        writer = csv.DictWriter(output, fieldnames=header, restval="")
+        writer.writeheader()
+        writer.writerows(rows)
+        value = output.getvalue().strip()
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def csv_dumps(data: list[dict], character_limit: typing.Optional[int] = None) -> str:
     # Dumps to CSV, with header row
     if not data:
@@ -74,22 +93,18 @@ def csv_dumps(data: list[dict], character_limit: typing.Optional[int] = None) ->
     else:
         limited_data = data
 
-    # Use the union of keys across rows: heterogeneous dicts are a routine
-    # shape for query results, and DictWriter raises on keys missing from
-    # fieldnames.
-    header = []
-    seen_keys = set()
-    for row in limited_data:
-        for key in row:
-            if key not in seen_keys:
-                seen_keys.add(key)
-                header.append(key)
-    with StringIO() as output:
-        writer = csv.DictWriter(output, fieldnames=header, restval="")
-        writer.writeheader()
-        writer.writerows(limited_data)
-        output = output.getvalue().strip()
-        output = output.replace("\r\n", "\n").replace("\r", "\n")
+    output = _dump_rows_csv(limited_data)
+
+    if character_limit:
+        # limit_data_size only counts populated key/value pairs, but the union
+        # header pads every row with one cell per column: rows with mostly
+        # disjoint keys can blow past the limit after serialization. Drop rows
+        # until the CSV fits.
+        while len(output) > character_limit and len(limited_data) > 1:
+            limited_data = limited_data[: len(limited_data) // 2]
+            output = _dump_rows_csv(limited_data)
+        if len(output) > character_limit:
+            return "Error: Too many fields to display data within the character limit."
 
     csv_content = f"```csv\n{output}\n```"
 
@@ -329,6 +344,9 @@ def _parse_docstring(func_name, docstring, signature_params):
                 f"{line!r} in the Args block to a parameter; it is ignored.",
                 stacklevel=3,
             )
+            # Lines indented under an unattributable line (eg an unknown
+            # subsection) must not leak into the previous parameter either
+            current_param = None
 
     description = " ".join(description_lines) if description_lines else None
     return description, param_descriptions

--- a/src/agentlys/utils.py
+++ b/src/agentlys/utils.py
@@ -2,7 +2,9 @@ import ast
 import asyncio
 import csv
 import inspect
+import re
 import typing
+import warnings
 from inspect import Parameter
 from io import StringIO
 from typing import Any
@@ -72,9 +74,18 @@ def csv_dumps(data: list[dict], character_limit: typing.Optional[int] = None) ->
     else:
         limited_data = data
 
-    header = list(data[0].keys())
+    # Use the union of keys across rows: heterogeneous dicts are a routine
+    # shape for query results, and DictWriter raises on keys missing from
+    # fieldnames.
+    header = []
+    seen_keys = set()
+    for row in limited_data:
+        for key in row:
+            if key not in seen_keys:
+                seen_keys.add(key)
+                header.append(key)
     with StringIO() as output:
-        writer = csv.DictWriter(output, fieldnames=header)
+        writer = csv.DictWriter(output, fieldnames=header, restval="")
         writer.writeheader()
         writer.writerows(limited_data)
         output = output.getvalue().strip()
@@ -235,36 +246,108 @@ class OmitClassJsonSchema(GenerateJsonSchema):
         raise PydanticOmit
 
 
+# Google-style Args entry: `name: description` or `name (type): description`
+_ARGS_PARAM_RE = re.compile(r"^(\*{0,2}\w+)\s*(?:\([^)]*\))?\s*:\s*(.*)$")
+
+# Section headers that end the Args block when they appear where a new
+# parameter entry would be expected.
+_DOCSTRING_SECTIONS = frozenset(
+    [
+        "returns",
+        "return",
+        "raises",
+        "yields",
+        "yield",
+        "examples",
+        "example",
+        "note",
+        "notes",
+        "attributes",
+    ]
+)
+
+
+def _parse_docstring(func_name, docstring, signature_params):
+    """Extract (description, param_descriptions) from a Google-style docstring.
+
+    The Args block is parsed indentation-aware: a line indented deeper than
+    the parameter entry it follows is accumulated into that parameter's
+    description. `(type)` suffixes are stripped from parameter names, and
+    names are validated against the function signature — a documented
+    parameter missing from the signature (or an unattributable line) emits
+    a warning instead of silently corrupting the schema.
+    """
+    description_lines = []
+    param_descriptions = {}
+    in_args = False
+    current_param = None  # parameter whose description is being accumulated
+    current_indent = 0
+
+    for raw_line in inspect.cleandoc(docstring).split("\n"):
+        line = raw_line.strip()
+        if not in_args:
+            if line.lower().startswith("args:"):
+                in_args = True
+            elif line:  # Only add non-empty lines to description
+                description_lines.append(line)
+            continue
+
+        if not line:
+            break
+        indent = len(raw_line) - len(raw_line.lstrip())
+        if current_param is not None and indent > current_indent:
+            # Indented continuation line of the current parameter entry
+            if current_param in param_descriptions:
+                param_descriptions[current_param] = (
+                    param_descriptions[current_param] + " " + line
+                ).strip()
+            continue
+
+        match = _ARGS_PARAM_RE.match(line)
+        if match:
+            param_name, param_desc = match.groups()
+            lookup_name = param_name.lstrip("*")
+            if lookup_name in signature_params:
+                current_param = lookup_name
+                current_indent = indent
+                param_descriptions[lookup_name] = param_desc.strip()
+                continue
+            if param_name.lower() in _DOCSTRING_SECTIONS:
+                break  # End of the Args block (Returns:, Raises:, ...)
+            warnings.warn(
+                f"Docstring of `{func_name}` documents parameter "
+                f"'{param_name}' which is not in the function signature; "
+                "it is ignored.",
+                stacklevel=3,
+            )
+            # Consume its continuation lines without attributing them
+            current_param = param_name
+            current_indent = indent
+        else:
+            warnings.warn(
+                f"Docstring of `{func_name}`: cannot attribute line "
+                f"{line!r} in the Args block to a parameter; it is ignored.",
+                stacklevel=3,
+            )
+
+    description = " ".join(description_lines) if description_lines else None
+    return description, param_descriptions
+
+
 def inspect_schema(f):
     kw = {}
     param_descriptions = {}
+    signature = inspect.signature(f)
 
     # Parse docstring and clean up the description
     description = None
     if f.__doc__:
-        doc_lines = f.__doc__.split("\n")
-        description_lines = []
-        in_args = False
-
-        for line in doc_lines:
-            line = line.strip()
-            if line.lower().startswith("args:"):
-                in_args = True
-                continue
-            if in_args:
-                if not line or line.lower().startswith("returns:"):
-                    break
-                if ":" in line:
-                    param_name, param_desc = line.split(":", 1)
-                    param_descriptions[param_name.strip()] = param_desc.strip()
-            else:
-                if line:  # Only add non-empty lines to description
-                    description_lines.append(line)
-
-        description = " ".join(description_lines) if description_lines else None
+        description, param_descriptions = _parse_docstring(
+            f.__name__, f.__doc__, set(signature.parameters)
+        )
 
     # Get function parameters
-    for n, o in inspect.signature(f).parameters.items():
+    for n, o in signature.parameters.items():
         # Skip 'self' parameter and 'from_response' parameter
         if n in ["self", "from_response"]:
             continue

--- a/tests/test_tool_result_formatting.py
+++ b/tests/test_tool_result_formatting.py
@@ -1,0 +1,121 @@
+"""Tool results that are hard to serialize must not crash the conversation turn.
+
+Formatting runs after the per-tool try/except of _execute_single_tool, so these
+tests exercise the error boundary around _format_callback_message: the turn
+must survive and the model must receive a usable function_result.
+"""
+
+from decimal import Decimal
+
+import pytest
+from agentlys import Agentlys
+from agentlys.model import Message, MessagePart
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_keys(monkeypatch):
+    """Agentlys() constructs an OpenAI client eagerly. These tests never hit
+    the wire — just make the constructor happy."""
+    monkeypatch.setenv("OPENAI_API_KEY", "fake")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake")
+
+
+def get_price() -> dict:
+    """Return a row with a json-unserializable Decimal amount."""
+    return {"amount": Decimal("19.99"), "currency": "EUR"}
+
+
+def get_rows() -> list:
+    """Return rows with heterogeneous keys."""
+    return [{"a": 1}, {"b": 2, "c": 3}]
+
+
+def get_raw_bytes() -> bytes:
+    """Return bytes that are not an image."""
+    return b"definitely not an image"
+
+
+class SessionHandle:
+    def close(self):
+        """Close the session."""
+
+
+def get_arbitrary_object() -> SessionHandle:
+    """Return an arbitrary object."""
+    return SessionHandle()
+
+
+def _function_call_part(name: str, call_id: str) -> MessagePart:
+    return MessagePart(
+        type="function_call",
+        function_call={"name": name, "arguments": {}},
+        function_call_id=call_id,
+    )
+
+
+async def _run_single_tool(function, call_id: str) -> Message:
+    agent = Agentlys()
+    agent.add_function(function)
+    part = _function_call_part(function.__name__, call_id)
+    response = Message(role="assistant", parts=[part])
+    return await agent._call_functions_parallel([part], response)
+
+
+@pytest.mark.asyncio
+async def test_decimal_dict_result_survives_the_turn():
+    result = await _run_single_tool(get_price, "call_decimal")
+
+    assert result.role == "function"
+    assert result.parts[0].type == "function_result"
+    assert "19.99" in result.parts[0].content
+
+
+@pytest.mark.asyncio
+async def test_heterogeneous_dict_list_result_survives_the_turn():
+    result = await _run_single_tool(get_rows, "call_rows")
+
+    assert result.role == "function"
+    content = result.parts[0].content
+    assert "a,b,c" in content  # header is the union of keys
+    assert ",2,3" in content  # missing keys are filled with empty values
+
+
+@pytest.mark.asyncio
+async def test_arbitrary_object_result_survives_the_turn():
+    result = await _run_single_tool(get_arbitrary_object, "call_object")
+
+    assert result.role == "function"
+    assert result.parts[0].type == "function_result"
+    assert result.parts[0].content  # a usable, non-empty text result
+
+
+@pytest.mark.asyncio
+async def test_formatting_error_becomes_function_result():
+    """Content that cannot be formatted (non-image bytes) is converted into an
+    error function_result instead of raising through the whole turn."""
+    result = await _run_single_tool(get_raw_bytes, "call_bytes")
+
+    assert result.role == "function"
+    assert result.parts[0].type == "function_result"
+    assert result.parts[0].function_call_id == "call_bytes"
+    assert "ValueError" in result.parts[0].content
+
+
+@pytest.mark.asyncio
+async def test_formatting_error_becomes_function_result_in_stream():
+    agent = Agentlys()
+    agent.add_function(get_raw_bytes)
+    part = _function_call_part("get_raw_bytes", "call_bytes_stream")
+    response = Message(role="assistant", parts=[part])
+
+    results = []
+    async for item in agent._stream_functions_parallel([part], response):
+        results.append(item)
+
+    assert len(results) == 1
+    function_call_id, function_name, message = results[0]
+    assert function_call_id == "call_bytes_stream"
+    assert function_name == "get_raw_bytes"
+    assert message.parts[0].type == "function_result"
+    assert message.parts[0].function_call_id == "call_bytes_stream"
+    assert "ValueError" in message.parts[0].content

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from pydantic import BaseModel
 
@@ -55,6 +56,11 @@ class TestCsvDumps(unittest.TestCase):
         output = csv_dumps([row], character_limit=20)
         self.assertIsInstance(output, str)
         self.assertIn("character limit", output)
+
+    def test_heterogeneous_dicts_use_union_of_keys(self):
+        output = csv_dumps([{"a": 1}, {"b": 2, "c": 3}])
+        expected = "```csv\na,b,c\n1,,\n,2,3\n```"
+        self.assertEqual(output, expected)
 
 
 plot_widget = """
@@ -267,6 +273,59 @@ def function_with_class_inherited_from_base_model(
     return a
 
 
+def function_with_multiline_param_description(query: str, limit: int = 10):
+    """Run a SQL query.
+
+    Args:
+        query: The SQL query to execute.
+            Only a single statement is allowed;
+            multiple statements raise an error.
+        limit: Maximum number of rows returned.
+    Returns:
+        The query results.
+    """
+    return query
+
+
+def function_with_colon_in_continuation(query: str):
+    """Run a SQL query.
+
+    Args:
+        query: The SQL query to execute.
+            Note: only SELECT statements are supported.
+    """
+    return query
+
+
+def function_with_type_suffix(count: int):
+    """Count things.
+
+    Args:
+        count (int): Number of items to count.
+    """
+    return count
+
+
+def function_with_unknown_param(a: int):
+    """Adds things.
+
+    Args:
+        a: The first number.
+        b: A parameter that does not exist in the signature.
+    """
+    return a
+
+
+def function_with_stray_args_line(a: int):
+    """Adds things.
+
+    Args:
+        a: The first number.
+    stray line that belongs to no parameter
+    """
+    return a
+
+
 class TestInspectSchema(unittest.TestCase):
     maxDiff = None
 
@@ -376,6 +435,62 @@ class TestInspectSchema(unittest.TestCase):
             },
         }
         self.assertEqual(result, expected)
+
+    def test_multiline_param_description_is_accumulated(self):
+        result = inspect_schema(function_with_multiline_param_description)
+        properties = result["parameters"]["properties"]
+        self.assertEqual(
+            properties["query"]["description"],
+            "The SQL query to execute. Only a single statement is allowed; "
+            "multiple statements raise an error.",
+        )
+        self.assertEqual(
+            properties["limit"]["description"],
+            "Maximum number of rows returned.",
+        )
+
+    def test_continuation_line_with_colon_is_not_a_ghost_parameter(self):
+        result = inspect_schema(function_with_colon_in_continuation)
+        properties = result["parameters"]["properties"]
+        self.assertEqual(list(properties), ["query"])
+        self.assertEqual(
+            properties["query"]["description"],
+            "The SQL query to execute. Note: only SELECT statements are supported.",
+        )
+
+    def test_type_suffix_is_stripped_from_parameter_name(self):
+        result = inspect_schema(function_with_type_suffix)
+        self.assertEqual(
+            result["parameters"]["properties"]["count"]["description"],
+            "Number of items to count.",
+        )
+
+    def test_documented_parameter_missing_from_signature_warns(self):
+        with self.assertWarns(UserWarning) as ctx:
+            result = inspect_schema(function_with_unknown_param)
+        self.assertIn("'b'", str(ctx.warning))
+        self.assertNotIn("b", result["parameters"]["properties"])
+        self.assertEqual(
+            result["parameters"]["properties"]["a"]["description"],
+            "The first number.",
+        )
+
+    def test_unattributable_args_line_warns(self):
+        with self.assertWarns(UserWarning) as ctx:
+            result = inspect_schema(function_with_stray_args_line)
+        self.assertIn("stray line", str(ctx.warning))
+        self.assertEqual(
+            result["parameters"]["properties"]["a"]["description"],
+            "The first number.",
+        )
+
+    def test_correct_docstrings_do_not_warn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            inspect_schema(sums)
+            inspect_schema(function_with_description_and_default_value)
+            inspect_schema(function_with_from_response)
+            inspect_schema(function_with_multiline_param_description)
 
     def test_inspect_schema_with_class_inherited_from_base_model(self):
         result = inspect_schema(function_with_class_inherited_from_base_model)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,15 @@ class TestCsvDumps(unittest.TestCase):
         expected = "```csv\na,b,c\n1,,\n,2,3\n```"
         self.assertEqual(output, expected)
 
+    def test_disjoint_keys_respect_character_limit(self):
+        # The union header pads every row with one cell per column, so rows
+        # with mostly disjoint keys can exceed the limit after serialization
+        data = [{f"key{i}": "v"} for i in range(200)]
+        output = csv_dumps(data, character_limit=1000)
+        self.assertLessEqual(len(output), 1200)
+        self.assertTrue(output.startswith("```csv"))
+        self.assertIn("rows displayed", output)
+
 
 plot_widget = """
 > PLOT_WIDGET(
@@ -326,6 +335,17 @@ def function_with_stray_args_line(a: int):
     return a
 
 
+def function_with_unknown_subsection(a: int):
+    """Adds things.
+
+    Args:
+        a: The first number.
+        See Also:
+            unrelated body that must not leak into the description
+    """
+    return a
+
+
 class TestInspectSchema(unittest.TestCase):
     maxDiff = None
 
@@ -479,6 +499,14 @@ class TestInspectSchema(unittest.TestCase):
         with self.assertWarns(UserWarning) as ctx:
             result = inspect_schema(function_with_stray_args_line)
         self.assertIn("stray line", str(ctx.warning))
+        self.assertEqual(
+            result["parameters"]["properties"]["a"]["description"],
+            "The first number.",
+        )
+
+    def test_unknown_subsection_does_not_leak_into_previous_param(self):
+        with self.assertWarns(UserWarning):
+            result = inspect_schema(function_with_unknown_subsection)
         self.assertEqual(
             result["parameters"]["properties"]["a"]["description"],
             "The first number.",


### PR DESCRIPTION
Fixes two long-standing robustness defects identified by an architecture review of the library's core paths.

## 1. Docstring parser silently corrupted tool schemas (`src/agentlys/utils.py`)

The Args block was parsed line-by-line with a bare `line.split(":", 1)`, which produced four reproducible failure modes:

- **(a)** multi-line parameter descriptions kept only the first line — continuation lines were silently dropped;
- **(b)** a continuation line containing a `:` became a ghost key, stealing the rest of the description;
- **(c)** Google-style type suffixes (`param (int):`) polluted the parameter key, so the description never attached to the real parameter;
- **(d)** a documented parameter missing from the signature passed without any signal.

The parser is now indentation-aware (Google-style): an indented continuation line accumulates into the current parameter's description, `(type)` suffixes are stripped, and every parsed name is validated against `inspect.signature` — unknown parameters and unattributable lines emit `warnings.warn` instead of silently corrupting the schema. Section headers (`Returns:`, `Raises:`, …) still end the Args block.

**Backward compatible**: existing single-line docstrings produce byte-identical schemas — all pre-existing snapshot tests pass unmodified, and a regression test asserts correct docstrings emit no warnings.

## 2. Tool result formatting ran outside the per-tool error boundary (`src/agentlys/chat.py`)

`_execute_single_tool` wraps tool execution in try/except, but `_format_callback_message` was called *after* it, unguarded, in both `_call_functions_parallel` and `_stream_functions_parallel`. A tool returning a `Decimal`-bearing dict (not JSON-serializable) or a list of heterogeneous dicts (`DictWriter` raises on unknown keys) crashed the whole conversation turn instead of producing an error `function_result` the model could react to.

- Formatting now runs through `_format_callback_message_safe`, which converts formatting exceptions into an error `function_result` via the existing `_format_exception` mechanism (`StopLoopException` still propagates).
- Depth fixes: `json.dumps(..., default=str)` for dict results carrying `Decimal`/`datetime`/`UUID`-like values, and `csv_dumps` now builds its header from the union of row keys with `restval=""` so heterogeneous dict lists serialize.

## Tests

- 4 unit tests reproducing each parser failure mode (fail before, pass after), plus warning tests and a no-warning regression guard.
- Formatting tests: `Decimal` dict, heterogeneous dict list, arbitrary object, and unformattable content (non-image bytes) — the turn survives and the model receives a usable `function_result`, in both the parallel and streaming paths.
- Full suite: 278 passed locally (the `tests/mcp_clients` suite spawns network-dependent subprocesses unavailable in the sandbox and is left to CI).

No public API change; providers and compaction untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqikiwdSiprb9b65ZH6R7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqikiwdSiprb9b65ZH6R7q)_