### PR TITLE
fix(anthropic): stop deciding strict tool use from the model name

### DIFF
--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -59,72 +59,6 @@ def _sha(payload) -> str:
     return hashlib.sha256(dump.encode("utf-8")).hexdigest()[:16]
 
 
-# Anthropic strict tool use relies on structured outputs and is only available
-# on these model families. Keep older models and Anthropic-compatible proxies
-# on best-effort tool calling instead of turning a valid request into a 400.
-_STRICT_TOOL_MODEL_PREFIXES = (
-    "claude-haiku-4-5",
-    "claude-opus-4-5",
-    "claude-opus-4-6",
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-opus-5",
-    "claude-sonnet-4-5",
-    "claude-sonnet-4-6",
-    "claude-sonnet-5",
-    "claude-fable-5",
-    "claude-mythos-5",
-)
-
-
-def _supports_strict_tool_use(model: str) -> bool:
-    # AGENTLYS_STRICT_TOOLS=0 disables auto-strict entirely (e.g. to mirror a
-    # proxy deployment where the model is a logical role and strict never fires).
-    if os.getenv("AGENTLYS_STRICT_TOOLS", "1") in ("0", "false", "no"):
-        return False
-    return model.lower().startswith(_STRICT_TOOL_MODEL_PREFIXES)
-
-
-def _schema_is_closed(schema) -> bool:
-    """True iff no object in the schema tree allows additional properties.
-
-    Anthropic rejects ``strict: true`` tools whose nested objects carry
-    ``additionalProperties: true`` (400 "not supported"), so auto-strict must
-    look past the top level.
-    """
-    if isinstance(schema, dict):
-        if schema.get("additionalProperties") is True:
-            return False
-        return all(_schema_is_closed(v) for v in schema.values())
-    if isinstance(schema, list):
-        return all(_schema_is_closed(v) for v in schema)
-    return True
-
-
-def _strict_schema_complexity(schema: dict) -> tuple[int, int]:
-    """Return Anthropic's counted optional-property and union totals."""
-    optional_properties = 0
-    unions = 0
-
-    def visit(value):
-        nonlocal optional_properties, unions
-        if isinstance(value, dict):
-            properties = value.get("properties")
-            if isinstance(properties, dict):
-                required = set(value.get("required", []))
-                optional_properties += len(set(properties) - required)
-            if "anyOf" in value or isinstance(value.get("type"), list):
-                unions += 1
-            for child in value.values():
-                visit(child)
-        elif isinstance(value, list):
-            for child in value:
-                visit(child)
-
-    visit(schema)
-    return optional_properties, unions
-
-
 def _canonical_key_order(value):
     """Rebuild dicts with sorted keys, recursively.  List order is preserved."""
     if isinstance(value, dict):
@@ -378,53 +312,26 @@ class AnthropicProvider(BaseProvider):
         """Translate function schemas to Anthropic tool definitions.
 
         Maps "parameters" to "input_schema" and guarantees a description.
-        Closed schemas use strict tool calling on supported models, within
-        Anthropic's documented per-request complexity limits.
+
+        ``strict`` is forwarded when the caller sets it and never inferred.
+        Deciding it here meant reading the model name, which is not something
+        a provider can rely on knowing: behind a gateway it is a logical role
+        or absent entirely, so the guess was wrong exactly where the schemas
+        were most worth constraining. Closed schemas
+        (``additionalProperties: false``, set in ``utils.inspect_schema``)
+        already tell the model which arguments exist; ``strict`` on top of
+        that is the caller's call, along with the per-request limits it has
+        to stay inside.
         """
         tools = []
-        explicit_strict_schemas = [
-            s["parameters"]
-            for s in self.chat.functions_schema
-            if s.get("strict") is True
-        ]
-        strict_tools = len(explicit_strict_schemas)
-        strict_optional_properties = 0
-        strict_unions = 0
-        for schema in explicit_strict_schemas:
-            optional_properties, unions = _strict_schema_complexity(schema)
-            strict_optional_properties += optional_properties
-            strict_unions += unions
-        supports_strict = _supports_strict_tool_use(self.model)
-
         for s in self.chat.functions_schema:
-            input_schema = s["parameters"]
             tool_def = {
                 "name": s["name"],
                 "description": s["description"] or "No description provided",
-                "input_schema": input_schema,
+                "input_schema": s["parameters"],
             }
-
-            explicit_strict = s.get("strict")
-            auto_strict = (
-                explicit_strict is None
-                and supports_strict
-                and input_schema.get("additionalProperties") is False
-                and _schema_is_closed(input_schema)
-            )
-            optional_properties, unions = _strict_schema_complexity(input_schema)
-            within_limits = (
-                strict_tools < 20
-                and strict_optional_properties + optional_properties <= 24
-                and strict_unions + unions <= 16
-            )
-            if explicit_strict is True:
+            if s.get("strict") is True:
                 tool_def["strict"] = True
-            elif auto_strict and within_limits:
-                tool_def["strict"] = True
-                strict_tools += 1
-                strict_optional_properties += optional_properties
-                strict_unions += unions
-
             if s.get("defer_loading"):
                 tool_def["defer_loading"] = True
             tools.append(tool_def)

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -6,6 +6,15 @@ from agentlys.providers.anthropic import message_to_anthropic_dict
 
 
 class TestStrictToolSchemas(unittest.TestCase):
+    """Closed schemas are automatic; ``strict`` is not.
+
+    Auto-strict used to be inferred from the model name. That guess is not
+    available to a provider pointed at a gateway -- the model is a logical
+    role, or None -- where it first silently never fired, then crashed on
+    ``None.lower()``. Schemas stay closed either way; the flag is the
+    caller's.
+    """
+
     @staticmethod
     def _archive_live_block(
         reason: str, name: str = "", live_block_id: str = ""
@@ -17,23 +26,35 @@ class TestStrictToolSchemas(unittest.TestCase):
         agent.add_function(self._archive_live_block)
         return agent.provider._build_tools()[0]
 
-    def test_supported_model_uses_strict_closed_schema(self):
+    def test_a_strict_capable_model_is_not_made_strict_implicitly(self):
         tool = self._tool_for_model("claude-haiku-4-5-20251001")
 
-        self.assertIs(tool["strict"], True)
+        self.assertNotIn("strict", tool)
         self.assertIs(tool["input_schema"]["additionalProperties"], False)
         self.assertEqual(
             set(tool["input_schema"]["properties"]),
             {"reason", "name", "live_block_id"},
         )
 
-    def test_unsupported_model_keeps_closed_schema_without_strict(self):
+    def test_an_older_model_also_keeps_the_closed_schema(self):
         tool = self._tool_for_model("claude-3-7-sonnet-latest")
 
         self.assertNotIn("strict", tool)
         self.assertIs(tool["input_schema"]["additionalProperties"], False)
 
-    def test_open_manual_schema_is_not_automatically_strict(self):
+    def test_a_model_the_gateway_resolves_builds_a_request(self):
+        """``provider.model`` is None whenever the caller leaves it to a
+        gateway; reading it to decide strict raised AttributeError on every
+        request, tools or not."""
+        agent = Agentlys(provider="anthropic", model=None, api_key="test")
+        agent.add_function(self._archive_live_block)
+
+        tools = agent.provider._build_tools()
+
+        self.assertEqual([tool["name"] for tool in tools], ["_archive_live_block"])
+        self.assertNotIn("strict", tools[0])
+
+    def test_an_explicit_strict_flag_is_forwarded(self):
         agent = Agentlys(
             provider="anthropic",
             model="claude-haiku-4-5-20251001",
@@ -41,15 +62,22 @@ class TestStrictToolSchemas(unittest.TestCase):
         )
         agent.functions_schema = [
             {
-                "name": "open_tool",
-                "description": "Accept arbitrary keys",
-                "parameters": {"type": "object", "properties": {}},
+                "name": "explicit_tool",
+                "description": "Must be strict",
+                "strict": True,
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
             }
         ]
 
-        self.assertNotIn("strict", agent.provider._build_tools()[0])
+        self.assertIs(agent.provider._build_tools()[0]["strict"], True)
 
-    def test_automatic_strict_tools_respect_provider_limit(self):
+    def test_many_tools_are_all_forwarded_unchanged(self):
+        """No implicit flag means no per-request budget to run out of: the
+        21st tool is built exactly like the first."""
         agent = Agentlys(
             provider="anthropic",
             model="claude-haiku-4-5-20251001",
@@ -69,44 +97,9 @@ class TestStrictToolSchemas(unittest.TestCase):
         ]
 
         tools = agent.provider._build_tools()
-        self.assertEqual(sum(tool.get("strict", False) for tool in tools), 20)
-        self.assertNotIn("strict", tools[-1])
 
-    def test_explicit_strict_tool_reserves_provider_capacity(self):
-        agent = Agentlys(
-            provider="anthropic",
-            model="claude-haiku-4-5-20251001",
-            api_key="test",
-        )
-        agent.functions_schema = [
-            {
-                "name": f"tool_{index}",
-                "description": "Tool",
-                "parameters": {
-                    "type": "object",
-                    "properties": {},
-                    "additionalProperties": False,
-                },
-            }
-            for index in range(20)
-        ]
-        agent.functions_schema.append(
-            {
-                "name": "explicit_tool",
-                "description": "Must be strict",
-                "strict": True,
-                "parameters": {
-                    "type": "object",
-                    "properties": {},
-                    "additionalProperties": False,
-                },
-            }
-        )
-
-        tools = agent.provider._build_tools()
-        self.assertEqual(sum(tool.get("strict", False) for tool in tools), 20)
-        self.assertNotIn("strict", tools[19])
-        self.assertIs(tools[-1]["strict"], True)
+        self.assertEqual(len(tools), 21)
+        self.assertTrue(all("strict" not in tool for tool in tools))
 
 
 class TestAnthropic(unittest.TestCase):

--- a/tests/test_cache_stability.py
+++ b/tests/test_cache_stability.py
@@ -747,25 +747,3 @@ class TestThinkingOnlyAssistantMessage(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-
-def test_auto_strict_skips_schemas_with_nested_open_objects():
-    from agentlys.providers.anthropic import _schema_is_closed
-
-    closed = {
-        "type": "object",
-        "additionalProperties": False,
-        "properties": {"a": {"type": "object", "additionalProperties": False}},
-    }
-    nested_open = {
-        "type": "object",
-        "additionalProperties": False,
-        "properties": {
-            "pipeline": {
-                "type": "array",
-                "items": {"type": "object", "additionalProperties": True},
-            }
-        },
-    }
-    assert _schema_is_closed(closed)
-    assert not _schema_is_closed(nested_open)


### PR DESCRIPTION
## Why

Auto-strict (added in #266, released in 1.16.2) decides `strict: true` by matching `self.model` against a list of physical Claude model ID prefixes. **A provider cannot rely on knowing that.** Behind a gateway the model is a logical role, or absent entirely because the gateway resolves it per caller. Both cases were mishandled:

- a logical role never matches a prefix → strict silently never fired;
- `model=None` → `AttributeError: 'NoneType' object has no attribute 'lower'`.

`_build_tools` runs on **every** request, tools or not, so the second case meant no request reached the API at all. It took `app.myriade.ai` down this morning — chat, automations, monitoring, audit, brief, nightly review, the integrations orchestrator, PR details, branch naming: everything that leaves the model to the proxy. myriade-private was pinned to 1.16.1, skipped 1.16.2/1.16.3, and picked auto-strict up with yesterday's 1.17.0 bump.

The guess was wrong exactly where the schemas were most worth constraining, and right only where the caller already knew the model and could have said so.

## What stays

**#266's actual fix is untouched.** Schemas are still closed — `additionalProperties: false`, set in `utils.inspect_schema` — which is what stops a model inventing a keyword argument that `func(**arguments)` then rejects with `TypeError`. That works on every model and every deployment, with no model name to read.

Explicit `strict: true` on a tool schema is still forwarded untouched, on Anthropic as on OpenAI.

## What goes

- `_STRICT_TOOL_MODEL_PREFIXES` — one more list to update on every model release.
- `_supports_strict_tool_use`, `_schema_is_closed`, `_strict_schema_complexity`.
- The per-request budget accounting (20 strict tools / 24 optional properties / 16 unions). Worth noting how it degraded: budgets were spent in `functions_schema` order, so past the cap a tool's guarantees depended on its registration position — and deferred (`defer_loading`) tools consumed the budget alongside the loaded ones.
- `AGENTLYS_STRICT_TOOLS`, the escape hatch that existed to turn the guess off. Its own comment named this failure — *"e.g. to mirror a proxy deployment where the model is a logical role and strict never fires"* — so the gateway case was known; only `None` was missed.

Net: **-122 lines**.

## Behaviour change

Callers on a **direct** Anthropic API, with closed schemas and a recent model, stop sending `strict: true`. They return to best-effort tool calling with closed schemas — what every caller had before 1.16.2, and what gateway callers have had throughout. Opt back in per tool with `strict: true`, which also puts the per-request limits somewhere the caller can reason about them.

Typed as `fix:` (patch). Say the word if you'd rather it were a minor bump given the removal.

## Tests

Rewrote `TestStrictToolSchemas` around the new contract, including a `model=None` case that reproduces the production `AttributeError` when the change is reverted. Dropped the `_schema_is_closed` unit test in `test_cache_stability.py` along with the helper.

Every test file passes — 321 tests. `tests/mcp_clients/test_mcp.py` hangs here for want of a live MCP server; it hangs identically on master.

Verified end to end against the consumer: with this branch installed and myriade-private's own workaround removed, the failing production path builds its request cleanly and still sends `model: null`.

## Consumer

myriade-ai/myriade-private#1156 works around this in `ProxyProvider._build_tools`. Once this is released and the floor bumped there, that override should be deleted — it exists only for this bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVrhzXZ7bdZcqxBUF9FuCT)_