### PR TITLE
fix(openai): report cached prompt tokens in usage

### DIFF
--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -49,13 +49,50 @@ def create_openai_client(
 
 
 def usage_to_dict(usage) -> typing.Optional[dict]:
-    """Normalize OpenAI usage to the input/output_tokens naming used by Message."""
+    """Normalize OpenAI usage to the naming used by Message.
+
+    OpenAI-compatible APIs report ``prompt_tokens`` as the *total* prompt size,
+    with cached and cache-written tokens as subsets of it
+    (``ordinary = prompt_tokens - cached_tokens - cache_write_tokens``), while
+    Anthropic reports ``input_tokens`` as the uncached remainder
+    (``total = input_tokens + cache_read + cache_creation``). We subtract both
+    subsets so the two providers share one shape — the shape
+    ``compaction.should_compact`` already sums.
+    """
     if usage is None:
         return None
-    return {
-        "input_tokens": usage.prompt_tokens,
-        "output_tokens": usage.completion_tokens,
+
+    prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+    details = getattr(usage, "prompt_tokens_details", None)
+
+    def _detail(name: str) -> int:
+        if details is None:
+            return 0
+        value = (
+            details.get(name)
+            if isinstance(details, dict)
+            else getattr(details, name, None)
+        )
+        return value or 0
+
+    # Cached reads are billed at a reduced rate, cache writes at a premium:
+    # keeping them separate is what makes cost attribution possible.
+    cache_read = _detail("cached_tokens")
+    cache_creation = _detail("cache_write_tokens")
+
+    # Guard against providers reporting subsets larger than the total.
+    cache_read = min(cache_read, prompt_tokens)
+    cache_creation = min(cache_creation, prompt_tokens - cache_read)
+
+    result = {
+        "input_tokens": prompt_tokens - cache_read - cache_creation,
+        "output_tokens": getattr(usage, "completion_tokens", 0) or 0,
     }
+    if cache_read:
+        result["cache_read_input_tokens"] = cache_read
+    if cache_creation:
+        result["cache_creation_input_tokens"] = cache_creation
+    return result
 
 
 def from_openai_object(

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -80,6 +80,12 @@ def usage_to_dict(usage) -> typing.Optional[dict]:
     cache_read = _detail("cached_tokens")
     cache_creation = _detail("cache_write_tokens")
 
+    # DeepSeek does not use prompt_tokens_details: it reports the same split as
+    # top-level fields, with the same invariant
+    # (prompt_tokens == prompt_cache_hit_tokens + prompt_cache_miss_tokens).
+    if not cache_read:
+        cache_read = getattr(usage, "prompt_cache_hit_tokens", None) or 0
+
     # Guard against providers reporting subsets larger than the total.
     cache_read = min(cache_read, prompt_tokens)
     cache_creation = min(cache_creation, prompt_tokens - cache_read)

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -14,6 +14,7 @@ from agentlys.providers.openai import (
     from_openai_object,
     message_to_openai_dict,
     split_function_results,
+    usage_to_dict,
 )
 
 
@@ -558,3 +559,81 @@ def test_return_image_as_user_message_does_not_mutate_history():
     transformed = return_image_as_user_message([original])
     assert transformed[0].role == "user"
     assert original.role == "function"
+
+
+class TestUsageToDict:
+    """Cached prompt tokens must be reported, not silently dropped."""
+
+    def test_none_usage(self):
+        assert usage_to_dict(None) is None
+
+    def test_without_cache(self):
+        usage = SimpleNamespace(
+            prompt_tokens=100, completion_tokens=20, prompt_tokens_details=None
+        )
+        assert usage_to_dict(usage) == {"input_tokens": 100, "output_tokens": 20}
+
+    def test_cached_tokens_are_split_out(self):
+        """prompt_tokens includes cached tokens; we report the Anthropic shape."""
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=768),
+        )
+        assert usage_to_dict(usage) == {
+            "input_tokens": 232,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 768,
+        }
+
+    def test_cache_write_tokens_are_split_out(self):
+        """cache_write_tokens is also a subset of prompt_tokens (billed 1.25x)."""
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=600, cache_write_tokens=300
+            ),
+        )
+        assert usage_to_dict(usage) == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 600,
+            "cache_creation_input_tokens": 300,
+        }
+
+    def test_total_is_preserved(self):
+        """compaction sums the three fields: they must add back up to the total."""
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=600, cache_write_tokens=300
+            ),
+        )
+        result = usage_to_dict(usage)
+        assert (
+            result["input_tokens"]
+            + result["cache_read_input_tokens"]
+            + result["cache_creation_input_tokens"]
+            == 1000
+        )
+
+    def test_details_as_dict(self):
+        """Some OpenAI-compatible servers return plain dicts."""
+        usage = SimpleNamespace(
+            prompt_tokens=500,
+            completion_tokens=10,
+            prompt_tokens_details={"cached_tokens": 400},
+        )
+        assert usage_to_dict(usage)["cache_read_input_tokens"] == 400
+
+    def test_inconsistent_cached_tokens_do_not_go_negative(self):
+        usage = SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=10,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=150),
+        )
+        result = usage_to_dict(usage)
+        assert result["input_tokens"] == 0
+        assert result["cache_read_input_tokens"] == 100

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -628,6 +628,21 @@ class TestUsageToDict:
         )
         assert usage_to_dict(usage)["cache_read_input_tokens"] == 400
 
+    def test_deepseek_style_top_level_fields(self):
+        """DeepSeek reports the split without prompt_tokens_details."""
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=20,
+            prompt_tokens_details=None,
+            prompt_cache_hit_tokens=768,
+            prompt_cache_miss_tokens=232,
+        )
+        assert usage_to_dict(usage) == {
+            "input_tokens": 232,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 768,
+        }
+
     def test_inconsistent_cached_tokens_do_not_go_negative(self):
         usage = SimpleNamespace(
             prompt_tokens=100,


### PR DESCRIPTION
## Problème

`usage_to_dict` (`src/agentlys/providers/openai.py`) ne remonte que `prompt_tokens` / `completion_tokens` et jette entièrement `usage.prompt_tokens_details`.

Conséquence pour les consommateurs : sur OpenAI et les APIs compatibles (GLM, ...), le cache est **invisible** (taux de hit à 0) et le coût est **faux**, alors que les tarifs diffèrent fortement — les lectures de cache sont facturées 0,1× le tarif d'entrée et les écritures 1,25×.

## Sémantique (vérifiée dans les docs des deux providers)

Les deux conventions sont **opposées** :

- **OpenAI** — `prompt_tokens` est le total, `cached_tokens` et `cache_write_tokens` en sont des sous-ensembles :
  `ordinary = prompt_tokens - cached_tokens - cache_write_tokens`
- **Anthropic** — `input_tokens` est le reste non caché :
  `total = input_tokens + cache_read_input_tokens + cache_creation_input_tokens`

Se contenter d'ajouter les champs de cache sans toucher à `input_tokens` aurait donc double-compté, notamment dans `compaction.should_compact` qui somme déjà les trois champs.

## Correctif

Les deux sous-ensembles sont soustraits de `prompt_tokens` et ré-exposés sous les noms Anthropic (`cache_read_input_tokens`, `cache_creation_input_tokens`). Les deux providers partagent désormais une seule forme, et la somme des trois champs reste égale au total du prompt.

Détails :
- `prompt_tokens_details` est accepté en objet **ou** en dict (certains serveurs OpenAI-compatibles renvoient du JSON brut).
- Les sous-ensembles sont bornés pour qu'un serveur incohérent ne produise pas un `input_tokens` négatif.
- Les champs de cache ne sont ajoutés que s'ils sont non nuls, pour ne pas changer la forme du dict en l'absence de cache.

## Tests

7 tests dans `tests/test_openai_compat.py`, sans réseau : usage absent, sans cache, cache read, cache write, `details` en dict, valeurs incohérentes, et invariant « la somme des trois champs redonne le total ».

## Hors périmètre

En streaming, `chat.completions.create(..., stream=True)` est appelé sans `stream_options={"include_usage": True}` : OpenAI n'émet alors jamais de chunk `usage`, donc la branche `if getattr(chunk, "usage", None)` est du code mort et le `usage` du message streamé reste `None` (cache *et* coût invisibles, compaction jamais déclenchée en streaming). Non corrigé ici car le flag n'est pas universellement supporté par tous les serveurs OpenAI-compatibles et mériterait un fallback — à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpqkopxnHSU7E5VVQBx8ZW