### PR TITLE
feat(cache): pin_tools_states() — reuse a persisted tool-states snapshot across turns

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -220,6 +220,7 @@ class Agentlys(AgentlysBase):
         self.compaction = compaction
         self.cancel_event = cancel_event
         self._initial_tools_states = None
+        self._tools_states_pinned = False
         self.functions_schema = []
         self.functions = {}
         self.tools = {}
@@ -311,6 +312,7 @@ class Agentlys(AgentlysBase):
         self._sub_agents = {}
         self.on_sub_agent_event = None
         self._initial_tools_states = None
+        self._tools_states_pinned = False
         self._tool_search_config = None
         self._tool_search_function_name = None
 
@@ -318,10 +320,28 @@ class Agentlys(AgentlysBase):
         """Clear and re-capture tool states.
 
         Useful when tools have mutated and you want to pick up the new state
-        without resetting the entire conversation.
+        without resetting the entire conversation.  Also lifts a
+        pin_tools_states() pin.
         """
+        self._tools_states_pinned = False
         self._initial_tools_states = None
         self._initial_tools_states = self.initial_tools_states
+
+    def pin_tools_states(self, states: str):
+        """Pin the tool-states system block to a caller-provided snapshot.
+
+        A new user message normally takes a fresh snapshot of the live
+        ``__llm__()`` values (see _capture_tools_states), which rewrites the
+        system prompt — and thus invalidates the whole cached prefix — as
+        soon as any of them drifted.  A caller that persists the block across
+        turns (e.g. per conversation, alongside its history) can pin it back
+        here before running: the block then stays byte-identical from turn to
+        turn and the cache survives.  Pass the exact string a previous
+        ``initial_tools_states`` returned.  The pin holds until
+        refresh_tools_states() or reset() lifts it.
+        """
+        self._initial_tools_states = states
+        self._tools_states_pinned = True
 
     @property
     def last_message(self):
@@ -338,9 +358,14 @@ class Agentlys(AgentlysBase):
         cached prefix mid-loop.  Capture once and reuse: a new human message
         starts a new turn and takes a fresh snapshot, tool results (role
         "function") keep the current one.  reset() / refresh_tools_states()
-        clear it explicitly.
+        clear it explicitly; a pin_tools_states() pin blocks the new-turn
+        recapture entirely.
         """
-        if message is not None and getattr(message, "role", None) == "user":
+        if (
+            message is not None
+            and getattr(message, "role", None) == "user"
+            and not self._tools_states_pinned
+        ):
             self._initial_tools_states = None
         if self._initial_tools_states is None:
             self._initial_tools_states = self.initial_tools_states

--- a/tests/test_cache_stability.py
+++ b/tests/test_cache_stability.py
@@ -745,5 +745,90 @@ class TestThinkingOnlyAssistantMessage(unittest.TestCase):
         self.assertNotIn("assistant", [m["role"] for m in messages])
 
 
+
+class TestPinnedToolsStates(unittest.TestCase):
+    """pin_tools_states(): a caller-provided snapshot survives new turns.
+
+    Without a pin, every new user message recaptures the live __llm__()
+    values, so any drift (a documented table, a moved counter) rewrites the
+    system prompt and invalidates the whole cached prefix on the next turn.
+    A caller that persists the block across turns pins it back instead.
+    """
+
+    def _agent_with_live_tool(self):
+        agent = Agentlys(
+            instruction="You are a test agent.",
+            provider=APIProvider.ANTHROPIC,
+            model="claude-sonnet-4-5",
+            api_key="test",
+        )
+        tool = LiveTool()
+        agent.add_tool(tool)
+        return agent, tool
+
+    def _drive_turn(self, agent, question):
+        create = AsyncMock(return_value=FakeResponse([{"type": "text", "text": "ok"}]))
+
+        async def drive():
+            with patch.object(agent.provider.client.messages, "create", create):
+                async for _ in agent.run_conversation_async(question):
+                    pass
+
+        _run(drive())
+        return create.await_args_list[-1].kwargs
+
+    def test_a_new_turn_recaptures_by_default(self):
+        agent, tool = self._agent_with_live_tool()
+        first = self._drive_turn(agent, "q1")
+        self.assertIn("LiveTool(calls=0)", json.dumps(first["system"]))
+
+        tool.calls = 7  # state drifts between the turns
+        second = self._drive_turn(agent, "q2")
+        self.assertIn("LiveTool(calls=7)", json.dumps(second["system"]))
+
+    def test_pinned_snapshot_survives_new_turns(self):
+        agent, tool = self._agent_with_live_tool()
+        agent.pin_tools_states(agent.initial_tools_states)
+
+        self._drive_turn(agent, "q1")
+        tool.calls = 7
+        second = self._drive_turn(agent, "q2")
+
+        dumped = json.dumps(second["system"])
+        self.assertIn("LiveTool(calls=0)", dumped)
+        self.assertNotIn("LiveTool(calls=7)", dumped)
+
+    def test_pin_uses_the_exact_provided_string(self):
+        agent, _ = self._agent_with_live_tool()
+        stored = (
+            "## Initial Tools States\nLiveTool(calls=3, from storage)\n"
+            "--- End of Initial Tools States ---"
+        )
+        agent.pin_tools_states(stored)
+        request = self._drive_turn(agent, "q1")
+        self.assertIn("LiveTool(calls=3, from storage)", json.dumps(request["system"]))
+
+    def test_refresh_lifts_the_pin(self):
+        agent, tool = self._agent_with_live_tool()
+        agent.pin_tools_states(agent.initial_tools_states)
+
+        tool.calls = 7
+        agent.refresh_tools_states()
+        request = self._drive_turn(agent, "q1")
+        self.assertIn("LiveTool(calls=7)", json.dumps(request["system"]))
+
+        # The pin is gone for good: the next turn recaptures again.
+        tool.calls = 9
+        second = self._drive_turn(agent, "q2")
+        self.assertIn("LiveTool(calls=9)", json.dumps(second["system"]))
+
+    def test_reset_lifts_the_pin(self):
+        agent, _ = self._agent_with_live_tool()
+        agent.pin_tools_states("pinned text")
+        agent.reset()
+        self.assertFalse(agent._tools_states_pinned)
+        self.assertIsNone(agent._initial_tools_states)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problème

Le bloc `## Initial Tools States` est recapturé à chaque nouveau message user (`_capture_tools_states`). Le gel de #158 protège la boucle d'outils *dans* un tour, mais pas la conversation : chez un consommateur qui reconstruit son objet Chat à chaque tour, toute dérive d'un `__llm__()` entre deux tours (table documentée, compteur bougé, sonde de fond) réécrit le prompt système — et le hash cumulatif du cache Anthropic invalide alors tout ce qui suit, **historique compris** (~10 800 tokens réécrits au lieu de ~100 chez Myriade).

En prod Myriade c'est la cause réparable dominante : **~280 invalidations début-de-tour/mois**.

## Solution

`chat.pin_tools_states(states)` : l'appelant qui persiste le bloc à côté de son historique le ré-épingle avant de lancer le tour. Le bloc reste byte-identique de tour en tour → le cache survit.

Sémantique :
- le pin bloque **uniquement** la recapture au nouveau message user ;
- `refresh_tools_states()` et `reset()` lèvent le pin — l'appelant rafraîchit exactement quand le cache est déjà mort (gap > TTL, compaction, sync du catalogue), jamais quand il est vivant ;
- on passe la chaîne exacte retournée par `initial_tools_states` (c'est elle qu'on persiste).

## Tests

`TestPinnedToolsStates` dans `tests/test_cache_stability.py` (5 tests) : recapture par défaut (contrôle), survie du pin à travers les tours avec un outil qui dérive, verbatim de la chaîne fournie, levée du pin par `refresh_tools_states()` puis retour au comportement normal, levée par `reset()`.

Suite : mêmes échecs préexistants que master à l'identique (env openai local), +5 passed.

## Suivi

Volet consommateur (Myriade service) : persister le snapshot par conversation + pin si dernier appel < TTL, refresh sur compaction/sync — PR séparée côté app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmPBBjQzcATvNe4cis2ek