### PR TITLE
fix(anthropic): drop signed-but-empty thinking blocks at serialization

### DIFF
--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -214,6 +214,15 @@ def message_to_anthropic_dict(message: Message) -> dict:
             continue
         if part.type == "thinking" and not keep_thinking:
             continue
+        if part.type == "thinking" and not part.is_redacted and not part.thinking:
+            # The model does emit signed thinking blocks with empty content,
+            # but the API refuses them on replay ('each thinking block must
+            # contain thinking', 400) when one sits on the last assistant
+            # message — which a replayed empty turn does. Dropping the block
+            # at worst invalidates the cached prefix; replaying it kills the
+            # conversation. Redacted blocks carry their payload in the
+            # signature and stay.
+            continue
         res["content"].append(part_to_anthropic_dict(part))
 
     return res

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -259,6 +259,36 @@ class TestThinkingReplay(unittest.TestCase):
             message_to_anthropic_dict(second)["content"][0]["type"], "thinking"
         )
 
+    def test_live_message_drops_empty_thinking(self):
+        """The model can emit a signed thinking block with empty content; the
+        API refuses to take it back ('each thinking block must contain
+        thinking', 400) once it sits on the last assistant message, killing
+        every later call of the conversation. Drop it at serialization."""
+        message = Message.from_anthropic_dict(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "", "signature": "sig"},
+                {"type": "text", "text": "answer"},
+            ],
+        )
+
+        blocks = message_to_anthropic_dict(message)["content"]
+
+        self.assertEqual(blocks, [{"type": "text", "text": "answer"}])
+
+    def test_live_message_drops_thinking_without_content_field(self):
+        message = Message.from_anthropic_dict(
+            role="assistant",
+            content=[
+                {"type": "thinking", "signature": "sig"},
+                {"type": "text", "text": "answer"},
+            ],
+        )
+
+        blocks = message_to_anthropic_dict(message)["content"]
+
+        self.assertEqual(blocks, [{"type": "text", "text": "answer"}])
+
     def test_load_messages_marks_history_as_stored(self):
         agent = Agentlys(provider=APIProvider.ANTHROPIC, api_key="test")
         live = self._live_assistant()


### PR DESCRIPTION
## Problem

Since #309, thinking blocks on `is_live` messages are replayed verbatim to keep the cached prefix stable. But the model can emit a **signed thinking block with empty content**, and the API refuses to take those back once one sits on the **last assistant message** of a request:

```
400 invalid_request_error: messages.N.content.0.thinking: each thinking block must contain thinking
```

That position is exactly where a fully empty assistant turn lands when a `simple_response_callback` re-asks after it. Callers that persist and reload thinking (`load_messages(keep_thinking=True)`) then replay the empty block on **every** later call — the conversation is permanently poisoned.

**Observed in production (2026-09-01)**: an org monitoring review on Vertex emitted three empty signed thinking blocks in one tool loop, ended a turn with an empty-thinking-only assistant message, and the nudge retry 400'd (`req_vrtx_011CecPzGDiv1ieUaMvgJQcT`). Verified in the DB: parts with `length(thinking) = 0` and a non-null signature.

## Fix

Filter non-redacted thinking parts with empty content in `message_to_anthropic_dict` — the single choke point every outgoing history passes through (live replay and reloaded-from-storage alike, so already-poisoned conversations heal on their next call). Dropping such a block at worst invalidates the cached prefix; replaying it kills the conversation. Redacted blocks (payload in the signature) are untouched.

## Tests

Two new tests in `TestThinkingReplay` (`thinking: ""` and missing `thinking` field), written red-first. `tests/test_anthropic.py`: 40/40. Full suite: 305 passed, 33 failed — the same 33 fail on `origin/master` (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4H42NB4guxu1kycnLVkGD