### PR TITLE
Add server-side tool search support for Anthropic

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -105,7 +105,7 @@ agent.add_tool(calc, "Calculator")
 
 ### Tool Search
 
-#### enable_tool_search(always_loaded=None, search_fn=None, search_model=None)
+#### enable_tool_search(always_loaded=None, search_fn=None, search_model=None, server_side=None)
 
 Enable tool search to defer most tools and discover them on-demand. Reduces context window usage and improves tool selection accuracy for agents with many tools.
 
@@ -126,8 +126,11 @@ agent.enable_tool_search(
 **Parameters:**
 
 - `always_loaded`: Tool names to keep always visible to the LLM. If `None`, only the search tool is visible.
-- `search_fn`: Custom async search function with signature `async def search(query: str, catalog: list[dict]) -> list[str]`. Each catalog entry has `name`, `description`, and `args` keys. If `None`, uses built-in keyword matching.
+- `search_fn`: Custom async search function with signature `async def search(query: str, catalog: list[dict]) -> list[str]`. Each catalog entry has `name`, `description`, and `args` keys. If `None`, uses built-in keyword matching. Providing one forces client-side search.
 - `search_model`: Model for LLM-based search (only used with custom `search_fn`). Defaults based on provider.
+- `server_side`: Use Anthropic's server-side tool search tool (`tool_search_tool_bm25`) instead of registering a local `tool_search` function. The API runs the search itself and expands the discovered tools inline, saving one LLM round-trip per discovery. Defaults to the `AGENTLYS_SERVER_TOOL_SEARCH` environment variable (`"1"`/`"true"` to enable). Silently falls back to client-side search on providers that don't support it (e.g. OpenAI).
+
+**Server-side mode (Anthropic only):** the provider injects `{"type": "tool_search_tool_bm25_20251119", "name": "tool_search_tool_bm25"}` into `tools`; deferred tools keep `defer_loading: true`. The `server_tool_use` / `tool_search_tool_result` blocks the API emits are kept in the history as dedicated message parts (`server_tool_use` / `server_tool_result`) and replayed verbatim — no `tool_result` is ever sent for a `srvtoolu_…` id.
 
 **How it works:**
 

--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -455,11 +455,12 @@ class Agentlys(AgentlysBase):
             methods_str = ", ".join(methods)
             lines.append(f"- {category}: {methods_str}")
 
-        return (
-            "## Searchable Tool Categories\n"
-            "Use the tool_search function to discover and load these tools:\n"
-            + "\n".join(lines)
+        intro = (
+            "Use the tool_search_tool_bm25 tool to discover and load these tools:"
+            if self._tool_search_config.server_side
+            else "Use the tool_search function to discover and load these tools:"
         )
+        return "## Searchable Tool Categories\n" + intro + "\n" + "\n".join(lines)
 
     def load_messages(self, messages: list[Message], keep_thinking: bool = False):
         """Restore a conversation from the caller's storage.
@@ -751,6 +752,7 @@ class Agentlys(AgentlysBase):
         always_loaded: typing.Optional[list[str]] = None,
         search_fn: typing.Optional[typing.Callable] = None,
         search_model: typing.Optional[str] = None,
+        server_side: typing.Optional[bool] = None,
     ):
         """Enable tool search to defer most tools and discover them on-demand.
 
@@ -770,15 +772,38 @@ class Agentlys(AgentlysBase):
                 ``async def search(query: str, catalog: list[dict]) -> list[str]``.
                 Each catalog entry has ``name`` and ``description`` keys.
                 If *None*, uses a default LLM-based search with a cheap model.
+                Providing one forces client-side search.
             search_model: Model to use for the default LLM-based search.
                 Ignored if *search_fn* is provided.  Defaults to
                 ``claude-haiku-4-5-20251001`` for Anthropic providers and
                 ``gpt-4o-mini`` for OpenAI providers.
+            server_side: Use Anthropic's server-side tool search tool
+                (``tool_search_tool_bm25``) instead of registering a local
+                search function — the API runs the search itself, saving one
+                LLM round-trip per discovery.  Defaults to the
+                ``AGENTLYS_SERVER_TOOL_SEARCH`` environment variable
+                ("1"/"true" to enable).  Silently falls back to client-side
+                search on providers that don't support it (e.g. OpenAI).
         """
-        from agentlys.tool_search import ToolSearchConfig, create_search_tool_fn
+        from agentlys.tool_search import (
+            ToolSearchConfig,
+            create_search_tool_fn,
+            server_tool_search_env_enabled,
+        )
 
         if always_loaded is None:
             always_loaded = []
+
+        # Server-side search needs an explicit opt-in (argument or env flag),
+        # a provider that supports it, and no custom search_fn — a custom
+        # search is by definition a client-side implementation.
+        if server_side is None:
+            server_side = server_tool_search_env_enabled()
+        server_side = (
+            bool(server_side)
+            and search_fn is None
+            and getattr(self.provider, "supports_server_tool_search", False)
+        )
 
         # Determine default search model based on provider
         if search_model is None:
@@ -796,11 +821,13 @@ class Agentlys(AgentlysBase):
                 for s in self.functions_schema
                 if s["name"] != self._tool_search_function_name
             ]
+            self._tool_search_function_name = None
 
         self._tool_search_config = ToolSearchConfig(
             always_loaded=always_loaded,
             search_fn=search_fn,
             search_model=search_model,
+            server_side=server_side,
         )
 
         # Mark all existing functions as deferred (except always_loaded).
@@ -811,6 +838,11 @@ class Agentlys(AgentlysBase):
                 schema.pop("defer_loading", None)
             else:
                 schema["defer_loading"] = True
+
+        if server_side:
+            # The provider injects the server tool definition at request time
+            # (see AnthropicProvider._build_tools); nothing to register here.
+            return
 
         # Register the search tool (never deferred)
         search_callable, search_schema = create_search_tool_fn(self)

--- a/src/agentlys/model.py
+++ b/src/agentlys/model.py
@@ -107,6 +107,12 @@ class MessagePart:
             "function_result_image",
             "thinking",
             "compaction",
+            # Server-side tool blocks (e.g. Anthropic's tool search):
+            # executed by the API itself, replayed verbatim in the history and
+            # never dispatched by the tool loop. The raw provider block rides
+            # in ``function_call``.
+            "server_tool_use",
+            "server_tool_result",
         ],
         content: typing.Optional[str] = None,  # TODO: should be named "text" !
         image: typing.Optional[PILImage.Image] = None,
@@ -405,6 +411,27 @@ class Message:
                         MessagePart(
                             type="compaction",
                             content=item.get("content", ""),
+                        )
+                    )
+                elif item["type"] == "server_tool_use":
+                    # A server-side tool call (e.g. Anthropic's tool search):
+                    # executed by the API, so it must be replayed verbatim and
+                    # never receive a client tool_result. Keep the raw block.
+                    parts.append(
+                        MessagePart(
+                            type="server_tool_use",
+                            function_call=item,
+                            function_call_id=item.get("id"),
+                        )
+                    )
+                elif item["type"] == "tool_search_tool_result":
+                    # Result of a server-side tool call, emitted inside the
+                    # assistant message. Kept verbatim for history replay.
+                    parts.append(
+                        MessagePart(
+                            type="server_tool_result",
+                            function_call=item,
+                            function_call_id=item.get("tool_use_id"),
                         )
                     )
                 elif item["type"] == "tool_use":

--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -24,6 +24,15 @@ _EXTENDED_TTL_BETA = "extended-cache-ttl-2025-04-11"
 # own default.
 _VALID_EFFORTS = ("low", "medium", "high", "xhigh", "max")
 
+# Anthropic's server-side tool search (BM25 variant: natural-language
+# queries). Injected into `tools` when the chat enables server-side tool
+# search; deferred tools are then discovered and expanded by the API itself,
+# with no client round-trip. GA — no beta header required.
+SERVER_TOOL_SEARCH_DEF = {
+    "type": "tool_search_tool_bm25_20251119",
+    "name": "tool_search_tool_bm25",
+}
+
 
 def _resolve_cache_ttl(value: str | None, env_var: str, default: str) -> str:
     ttl = value or os.getenv(env_var) or default
@@ -173,6 +182,14 @@ def part_to_anthropic_dict(part: MessagePart) -> dict:
         else:
             result["content"] = part.content
         return result
+    elif part.type in ("server_tool_use", "server_tool_result"):
+        # Replay the raw API block verbatim — the API executed the tool, so
+        # the client must neither rewrite it nor answer it with a
+        # tool_result. Canonical key order rebuilds a fresh structure (no
+        # shared mutation when cache_control is stamped on it) and keeps the
+        # serialization byte-stable after a store that reorders object keys
+        # (Postgres jsonb), mirroring the tool_use "input" handling above.
+        return _canonical_key_order(part.function_call)
     elif part.type == "thinking":
         if part.is_redacted:
             return {
@@ -232,6 +249,8 @@ DEFAULT_MAX_TOKENS = int(os.getenv("ANTHROPIC_MAX_TOKENS", "10000"))
 
 
 class AnthropicProvider(BaseProvider):
+    supports_server_tool_search = True
+
     def __init__(
         self,
         chat: AgentlysBase,
@@ -344,6 +363,16 @@ class AnthropicProvider(BaseProvider):
             if s.get("defer_loading"):
                 tool_def["defer_loading"] = True
             tools.append(tool_def)
+
+        # Server-side tool search: the API runs the search itself, so no
+        # local tool_search function is registered (see enable_tool_search).
+        # The server tool leads the list and is never deferred — the API
+        # requires at least one non-deferred tool.
+        tool_search_config = getattr(self.chat, "_tool_search_config", None)
+        if tool_search_config is not None and getattr(
+            tool_search_config, "server_side", False
+        ):
+            tools.insert(0, dict(SERVER_TOOL_SEARCH_DEF))
         return tools
 
     def _build_system_blocks(self) -> list[dict]:

--- a/src/agentlys/providers/base_provider.py
+++ b/src/agentlys/providers/base_provider.py
@@ -15,6 +15,11 @@ class APIProvider(Enum):
 
 
 class BaseProvider(ABC):
+    # Whether the provider can run Anthropic's server-side tool search tool
+    # (see AnthropicProvider). enable_tool_search() checks this before
+    # switching to server-side mode.
+    supports_server_tool_search = False
+
     def prepare_messages(
         self,
         transform_function: typing.Callable,

--- a/src/agentlys/tool_search.py
+++ b/src/agentlys/tool_search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -12,6 +13,16 @@ if TYPE_CHECKING:
     from agentlys.base import AgentlysBase
 
 logger = logging.getLogger(__name__)
+
+# Feature flag for Anthropic's server-side tool search. When enabled (and the
+# provider supports it), enable_tool_search() skips registering the local
+# tool_search function and the Anthropic provider injects the server tool
+# instead — saving the extra LLM round-trip our client-side search costs.
+SERVER_TOOL_SEARCH_ENV = "AGENTLYS_SERVER_TOOL_SEARCH"
+
+
+def server_tool_search_env_enabled() -> bool:
+    return os.getenv(SERVER_TOOL_SEARCH_ENV, "").lower() in ("1", "true", "yes")
 
 
 @dataclass
@@ -24,11 +35,15 @@ class ToolSearchConfig:
             ``async def search(query: str, catalog: list[dict]) -> list[str]``.
             If *None*, uses a default LLM-based search with a cheap model.
         search_model: Model to use for the default LLM-based search.
+        server_side: Use Anthropic's server-side tool search tool instead of a
+            locally registered search function. Set by ``enable_tool_search``
+            only when the provider supports it.
     """
 
     always_loaded: list[str] = field(default_factory=list)
     search_fn: Optional[Callable] = None
     search_model: str = "claude-haiku-4-5-20251001"
+    server_side: bool = False
 
 
 _STOP_WORDS = frozenset({

--- a/tests/test_tool_search.py
+++ b/tests/test_tool_search.py
@@ -3,7 +3,11 @@
 import pytest
 from agentlys import Agentlys, APIProvider, ToolSearchConfig
 from agentlys.model import Message, MessagePart
-from agentlys.providers.anthropic import part_to_anthropic_dict
+from agentlys.providers.anthropic import (
+    SERVER_TOOL_SEARCH_DEF,
+    message_to_anthropic_dict,
+    part_to_anthropic_dict,
+)
 from agentlys.tool_search import create_search_tool_fn, _default_search
 
 
@@ -566,6 +570,197 @@ def test_enable_tool_search_reconfigure_clears_defer_for_new_always_loaded():
         s for s in agent.functions_schema if s["name"] == "_dummy_fn_b"
     )
     assert "defer_loading" not in schema_b
+
+
+# ── Server-side tool search (Anthropic) ──────────────────────────────────────
+
+SERVER_TOOL_USE_BLOCK = {
+    "type": "server_tool_use",
+    "id": "srvtoolu_01ABC123",
+    "name": "tool_search_tool_bm25",
+    "input": {"query": "weather tools"},
+}
+
+TOOL_SEARCH_RESULT_BLOCK = {
+    "type": "tool_search_tool_result",
+    "tool_use_id": "srvtoolu_01ABC123",
+    "content": {
+        "type": "tool_search_tool_search_result",
+        "tool_references": [{"type": "tool_reference", "tool_name": "get_weather"}],
+    },
+}
+
+
+def test_server_side_skips_local_search_function():
+    """server_side=True must not register the local tool_search function."""
+    agent = Agentlys(provider=APIProvider.ANTHROPIC)
+    agent.add_function(_dummy_fn_a)
+
+    agent.enable_tool_search(server_side=True)
+
+    assert agent._tool_search_config.server_side is True
+    assert agent._tool_search_function_name is None
+    assert "tool_search" not in agent.functions
+    assert not any(s["name"] == "tool_search" for s in agent.functions_schema)
+    # Other tools are still deferred
+    schema = next(s for s in agent.functions_schema if s["name"] == "_dummy_fn_a")
+    assert schema.get("defer_loading") is True
+
+
+def test_server_side_env_flag(monkeypatch):
+    """AGENTLYS_SERVER_TOOL_SEARCH=1 enables server-side mode by default."""
+    monkeypatch.setenv("AGENTLYS_SERVER_TOOL_SEARCH", "1")
+    agent = Agentlys(provider=APIProvider.ANTHROPIC)
+    agent.add_function(_dummy_fn_a)
+
+    agent.enable_tool_search()
+
+    assert agent._tool_search_config.server_side is True
+    assert "tool_search" not in agent.functions
+
+
+def test_server_side_env_flag_off_keeps_client_side(monkeypatch):
+    """Without the flag, behavior is unchanged (local search function)."""
+    monkeypatch.delenv("AGENTLYS_SERVER_TOOL_SEARCH", raising=False)
+    agent = Agentlys(provider=APIProvider.ANTHROPIC)
+    agent.add_function(_dummy_fn_a)
+
+    agent.enable_tool_search()
+
+    assert agent._tool_search_config.server_side is False
+    assert "tool_search" in agent.functions
+
+
+def test_server_side_falls_back_on_openai(monkeypatch):
+    """Non-Anthropic providers fall back to the client-side search."""
+    monkeypatch.setenv("AGENTLYS_SERVER_TOOL_SEARCH", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    agent = Agentlys(provider=APIProvider.OPENAI, model="gpt-4o")
+    agent.add_function(_dummy_fn_a)
+
+    agent.enable_tool_search(server_side=True)
+
+    assert agent._tool_search_config.server_side is False
+    assert "tool_search" in agent.functions
+
+
+def test_server_side_custom_search_fn_forces_client_side():
+    """A custom search_fn is a client-side implementation by definition."""
+    agent = Agentlys(provider=APIProvider.ANTHROPIC)
+    agent.add_function(_dummy_fn_a)
+
+    async def my_search(query: str, catalog: list[dict]) -> list[str]:
+        return []
+
+    agent.enable_tool_search(search_fn=my_search, server_side=True)
+
+    assert agent._tool_search_config.server_side is False
+    assert "tool_search" in agent.functions
+
+
+def test_reenable_switches_between_modes():
+    """Re-enabling can move between client-side and server-side cleanly."""
+    agent = Agentlys(provider=APIProvider.ANTHROPIC)
+    agent.add_function(_dummy_fn_a)
+
+    agent.enable_tool_search()
+    assert "tool_search" in agent.functions
+
+    agent.enable_tool_search(server_side=True)
+    assert "tool_search" not in agent.functions
+    assert not any(s["name"] == "tool_search" for s in agent.functions_schema)
+
+    agent.enable_tool_search(server_side=False)
+    assert "tool_search" in agent.functions
+    assert agent._tool_search_config.server_side is False
+
+
+def test_build_tools_injects_server_tool_def():
+    """The Anthropic provider injects the server tool, never deferred, first."""
+    agent = Agentlys(provider=APIProvider.ANTHROPIC)
+    agent.add_function(_dummy_fn_a)
+    agent.add_function(_dummy_fn_b)
+    agent.enable_tool_search(always_loaded=["_dummy_fn_b"], server_side=True)
+
+    agent.messages = [Message(role="user", content="test")]
+    messages, tools, kwargs = agent.provider._prepare_request_params()
+
+    assert tools[0]["type"] == SERVER_TOOL_SEARCH_DEF["type"]
+    assert tools[0]["name"] == "tool_search_tool_bm25"
+    assert "defer_loading" not in tools[0]
+    tool_a = next(t for t in tools if t.get("name") == "_dummy_fn_a")
+    tool_b = next(t for t in tools if t.get("name") == "_dummy_fn_b")
+    assert tool_a.get("defer_loading") is True
+    assert not tool_b.get("defer_loading")
+    assert not any(t.get("name") == "tool_search" for t in tools)
+
+
+def test_build_tools_no_server_tool_in_client_mode():
+    """Client-side mode keeps the current tools payload (no server def)."""
+    agent = Agentlys(provider=APIProvider.ANTHROPIC)
+    agent.add_function(_dummy_fn_a)
+    agent.enable_tool_search()
+
+    agent.messages = [Message(role="user", content="test")]
+    messages, tools, kwargs = agent.provider._prepare_request_params()
+
+    assert not any(t.get("type") == SERVER_TOOL_SEARCH_DEF["type"] for t in tools)
+    assert any(t.get("name") == "tool_search" for t in tools)
+
+
+def test_from_anthropic_dict_parses_server_tool_blocks():
+    """server_tool_use / tool_search_tool_result become dedicated parts."""
+    msg = Message.from_anthropic_dict(
+        role="assistant",
+        content=[
+            {"type": "text", "text": "Searching for tools."},
+            SERVER_TOOL_USE_BLOCK,
+            TOOL_SEARCH_RESULT_BLOCK,
+            {
+                "type": "tool_use",
+                "id": "toolu_01XYZ",
+                "name": "get_weather",
+                "input": {"location": "SF"},
+            },
+        ],
+    )
+
+    types = [p.type for p in msg.parts]
+    assert types == ["text", "server_tool_use", "server_tool_result", "function_call"]
+    # The tool loop must only execute the real tool_use — never respond to a
+    # srvtoolu_… id with a tool_result.
+    assert [p.function_call["name"] for p in msg.function_call_parts] == [
+        "get_weather"
+    ]
+
+
+def test_server_tool_blocks_replayed_verbatim():
+    """History replay sends the raw blocks back unchanged (no tool_result)."""
+    msg = Message.from_anthropic_dict(
+        role="assistant",
+        content=[SERVER_TOOL_USE_BLOCK, TOOL_SEARCH_RESULT_BLOCK],
+    )
+
+    replayed = message_to_anthropic_dict(msg)
+
+    assert replayed["role"] == "assistant"
+    assert replayed["content"][0] == SERVER_TOOL_USE_BLOCK
+    assert replayed["content"][1] == TOOL_SEARCH_RESULT_BLOCK
+    assert not any(b.get("type") == "tool_result" for b in replayed["content"])
+
+
+def test_server_tool_replay_not_polluted_by_cache_control():
+    """Mutating one serialization (cache_control) must not leak into the next."""
+    msg = Message.from_anthropic_dict(
+        role="assistant",
+        content=[SERVER_TOOL_USE_BLOCK, TOOL_SEARCH_RESULT_BLOCK],
+    )
+
+    first = message_to_anthropic_dict(msg)
+    first["content"][-1]["cache_control"] = {"type": "ephemeral"}
+
+    second = message_to_anthropic_dict(msg)
+    assert "cache_control" not in second["content"][-1]
 
 
 # ── Anthropic empty tool_references test ─────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR adds support for Anthropic's server-side tool search (`tool_search_tool_bm25`), allowing the API to execute tool discovery itself rather than requiring a client-side round-trip. This reduces latency and context window usage when agents have many deferred tools.

## Key Changes

- **Server-side tool search mode**: Added `server_side` parameter to `enable_tool_search()` that uses Anthropic's native `tool_search_tool_bm25` tool instead of registering a local search function
- **Environment flag**: Introduced `AGENTLYS_SERVER_TOOL_SEARCH` environment variable to enable server-side mode by default
- **Provider support detection**: Added `supports_server_tool_search` attribute to `BaseProvider` (enabled for Anthropic only)
- **Message parsing**: Extended `Message.from_anthropic_dict()` to recognize and preserve `server_tool_use` and `tool_search_tool_result` blocks as dedicated message parts
- **Serialization**: Updated `part_to_anthropic_dict()` and `message_to_anthropic_dict()` to replay server-side tool blocks verbatim without modification
- **Tool injection**: Modified `AnthropicProvider._build_tools()` to inject the server tool definition at the start of the tools list when server-side mode is enabled
- **Fallback logic**: Server-side mode automatically falls back to client-side search for unsupported providers or when a custom `search_fn` is provided
- **Documentation**: Updated API reference and tool search hints to reflect server-side mode

## Implementation Details

- Server-side tool blocks are stored in `MessagePart.function_call` with types `server_tool_use` and `server_tool_result` to distinguish them from regular tool calls
- The server tool is never deferred and always appears first in the tools list (API requirement)
- Serialization uses canonical key ordering to prevent mutation leaks when cache control headers are added
- The feature gracefully degrades on non-Anthropic providers while respecting explicit `server_side=True` requests
- Re-enabling tool search can switch between client-side and server-side modes cleanly

https://claude.ai/code/session_0169Q83hKMyqaHoHc1pg1PBq