### PR TITLE
feat(openai): Responses API provider with reasoning (GPT-5 / o-series)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -30,6 +30,48 @@ agent = Agentlys(provider="openai")
 agent = Agentlys(provider="openai", model="gpt-5-mini")
 ```
 
+### OpenAI Responses API (GPT-5 / o-series reasoning)
+
+The `openai_responses` provider targets the Responses API, which is the only
+OpenAI API that carries a reasoning model's hidden state across the turns of
+a tool loop. Use it for GPT-5 / o-series models; the plain `openai`
+provider (Chat Completions) restarts the reasoning from scratch after every
+tool result.
+
+```python
+agent = Agentlys(provider="openai_responses", model="gpt-5.4", effort="high")
+```
+
+- **Reasoning** — `effort` accepts the OpenAI levels (`none`, `minimal`,
+  `low`, `medium`, `high`, `xhigh`) plus Anthropic's `max` (mapped to
+  `xhigh`), so one setting works across providers; an Anthropic-style
+  `thinking=` config is translated (`enabled` scales with `budget_tokens`,
+  `adaptive` leaves the model's default). A summary is requested
+  (`reasoning.summary="auto"`) and streamed as `{"type": "thinking"}` chunks.
+- **Round-trip** — each turn's reasoning is stored as a `thinking`
+  MessagePart whose `thinking_signature` is
+  `"<reasoning item id>|<encrypted_content>"`. Persist `thinking` and
+  `thinking_signature` byte-for-byte and reload with
+  `load_messages(keep_thinking=True)` exactly as for Anthropic; requests use
+  `store=false`, nothing is retained on OpenAI's side.
+- **Streaming** — yields `text`, `thinking`, `tool_started` (`name`, `id`,
+  `index`) and `tool_delta` (`partial_json`) chunks before the final
+  `message`. Usage (including `cache_read_input_tokens` and
+  `reasoning_tokens`) arrives with the completed response, so compaction
+  works in streaming mode.
+- **Tool search** — the API has no deferred loading; deferred tools are
+  hidden until a `tool_search` result references them, the same economy as
+  Anthropic's `defer_loading`.
+- `base_url`, `api_key`, `AGENTLYS_HOST`, `AGENTLYS_API_KEY` and
+  `default_headers` (constructor only) work as for the `openai` provider.
+  `cache_ttl` / `cache_ttl_messages` are accepted and ignored — OpenAI
+  caches prompt prefixes automatically.
+
+The `openai` provider also maps `effort` / `thinking` to `reasoning_effort`,
+hides deferred tools the same way, requests usage in streams and uses
+`max_completion_tokens`, so reasoning models work there too — without the
+cross-turn reasoning state.
+
 ### Anthropic
 
 Anthropic's Claude models, recommended for agentic behavior.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -59,17 +59,21 @@ agent = Agentlys(provider="openai_responses", model="gpt-5.4", effort="high")
   `message`. Usage (including `cache_read_input_tokens` and
   `reasoning_tokens`) arrives with the completed response, so compaction
   works in streaming mode.
-- **Tool search** — the API has no deferred loading; deferred tools are
-  hidden until a `tool_search` result references them, the same economy as
-  Anthropic's `defer_loading`.
+- **Tool search** — agentlys keeps its own client-side search tool rather
+  than the API's native `tool_search`; deferred tools are hidden until a
+  search result references them, the same economy as Anthropic's
+  `defer_loading` (the tool list changes when a tool loads, which resets
+  OpenAI's automatic prefix cache for that request).
 - `base_url`, `api_key`, `AGENTLYS_HOST`, `AGENTLYS_API_KEY` and
   `default_headers` (constructor only) work as for the `openai` provider.
   `cache_ttl` / `cache_ttl_messages` are accepted and ignored — OpenAI
   caches prompt prefixes automatically.
 
 The `openai` provider also maps `effort` / `thinking` to `reasoning_effort`,
-hides deferred tools the same way, requests usage in streams and uses
-`max_completion_tokens`, so reasoning models work there too — without the
+hides deferred tools the same way, requests usage in streams
+(`AGENTLYS_OPENAI_STREAM_USAGE=0` opts out) and uses `max_completion_tokens`
+(`AGENTLYS_OPENAI_LEGACY_MAX_TOKENS=1` keeps `max_tokens` for gateways that
+reject the new field), so reasoning models work there too — without the
 cross-turn reasoning state.
 
 ### Anthropic

--- a/src/agentlys/providers/anthropic.py
+++ b/src/agentlys/providers/anthropic.py
@@ -54,6 +54,16 @@ def _resolve_effort(value: str | None) -> str | None:
     return effort
 
 
+def is_anthropic_signature(signature: str | None) -> bool:
+    """Whether a thinking signature was issued by this API.
+
+    The OpenAI Responses provider stores its reasoning state in the same
+    field as ``"<item id>|<encrypted_content>"``; Anthropic signatures are
+    base64 and never contain the separator.
+    """
+    return bool(signature) and "|" not in signature
+
+
 def _sha(payload) -> str:
     dump = json.dumps(payload, sort_keys=True, default=str)
     return hashlib.sha256(dump.encode("utf-8")).hexdigest()[:16]
@@ -222,6 +232,14 @@ def message_to_anthropic_dict(message: Message) -> dict:
             # at worst invalidates the cached prefix; replaying it kills the
             # conversation. Redacted blocks carry their payload in the
             # signature and stay.
+            continue
+        if (
+            part.type == "thinking"
+            and not part.is_redacted
+            and not is_anthropic_signature(part.thinking_signature)
+        ):
+            # A block produced by the OpenAI Responses provider (signature
+            # "<id>|<encrypted_content>"): replaying it here is a 400.
             continue
         res["content"].append(part_to_anthropic_dict(part))
 

--- a/src/agentlys/providers/base_provider.py
+++ b/src/agentlys/providers/base_provider.py
@@ -8,6 +8,7 @@ from agentlys.utils import get_event_loop_or_create
 
 class APIProvider(Enum):
     OPENAI = "openai"
+    OPENAI_RESPONSES = "openai_responses"
     OPENAI_FUNCTION_LEGACY = "openai_function_legacy"
     OPENAI_FUNCTION_SHIM = "openai_function_shim"
     ANTHROPIC = "anthropic"

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -13,11 +13,57 @@ from agentlys.providers.utils import (
 
 OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1"
 
+# reasoning effort values the API accepts. Availability varies per model
+# generation (``minimal`` is gpt-5 only, ``none`` needs gpt-5.1+, ``xhigh``
+# gpt-5.2+); the provider forwards whatever it is given and lets the API
+# reject a value the target model does not support.
+_VALID_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh")
+
+# Anthropic ``output_config.effort`` levels that have no OpenAI namesake.
+_EFFORT_ALIASES = {"max": "xhigh"}
+
+
+def resolve_effort(value: typing.Optional[str]) -> typing.Optional[str]:
+    """Normalize an effort level to what OpenAI accepts.
+
+    Accepts the OpenAI levels as-is and translates the Anthropic-only ones,
+    so a caller can keep one ``effort=`` setting across providers.
+    """
+    effort = value or os.getenv("AGENTLYS_EFFORT") or None
+    if effort is None:
+        return None
+    effort = _EFFORT_ALIASES.get(effort, effort)
+    if effort not in _VALID_EFFORTS:
+        raise ValueError(
+            f"Invalid effort {effort!r}: expected one of {_VALID_EFFORTS} "
+            f"or {tuple(_EFFORT_ALIASES)}"
+        )
+    return effort
+
+
+def thinking_to_effort(thinking: typing.Optional[dict]) -> typing.Optional[str]:
+    """Map an Anthropic ``thinking`` config onto a reasoning effort.
+
+    ``enabled`` scales with the budget the caller had in mind. ``adaptive``
+    and ``disabled`` send nothing: the former is the API's own default, and
+    for the latter any explicit effort would be a 400 on a model without
+    reasoning (gpt-4o, an Ollama model, ...).
+    """
+    if not thinking or thinking.get("type") != "enabled":
+        return None
+    budget = thinking.get("budget_tokens") or 0
+    if budget < 2048:
+        return "low"
+    if budget < 8192:
+        return "medium"
+    return "high"
+
 
 def create_openai_client(
     base_url: typing.Optional[str] = None,
     api_key: typing.Optional[str] = None,
     host_suffix: str = "",
+    default_headers: typing.Optional[dict] = None,
 ):
     """Build an AsyncOpenAI client for OpenAI or any OpenAI-compatible API.
 
@@ -45,6 +91,7 @@ def create_openai_client(
     return AsyncOpenAI(
         base_url=resolved_base_url or OPENAI_DEFAULT_BASE_URL,
         api_key=resolved_api_key,
+        default_headers=default_headers,
     )
 
 
@@ -239,9 +286,7 @@ def message_to_openai_dict(message: Message) -> dict:
         res = {"role": message.role, "content": []}
         for part in message.parts:
             if part.type == "thinking":
-                # Chat Completions has no reasoning-state item: a stored
-                # thinking block (Anthropic or Responses API) is simply
-                # not replayable here.
+                # Chat Completions has no reasoning-state item.
                 continue
             if part.type == "function_call" and message.role == "assistant":
                 res.setdefault("tool_calls", []).append(
@@ -331,8 +376,6 @@ class OpenAIProvider(BaseProvider):
         cache_ttl: typing.Optional[str] = None,
         cache_ttl_messages: typing.Optional[str] = None,
     ):
-        from agentlys.providers.openai_responses import resolve_effort
-
         self.chat = chat
         self.model = model
         self.effort = resolve_effort(effort)
@@ -359,11 +402,6 @@ class OpenAIProvider(BaseProvider):
         translated Anthropic-style ``thinking`` config. ``thinking`` itself
         is never forwarded: the API rejects unknown parameters.
         """
-        from agentlys.providers.openai_responses import (
-            resolve_effort,
-            thinking_to_effort,
-        )
-
         thinking = kwargs.pop("thinking", None) or getattr(self.chat, "thinking", None)
         effort = resolve_effort(kwargs.pop("effort", None)) or getattr(
             self, "effort", None
@@ -384,6 +422,17 @@ class OpenAIProvider(BaseProvider):
             ),
         )
 
+        # An assistant turn holding nothing but a thinking block serializes
+        # to content=None with no tool_calls, which the API rejects.
+        messages = [
+            m
+            for m in messages
+            if not (
+                m.get("role") == "assistant"
+                and not m.get("content")
+                and not m.get("tool_calls")
+            )
+        ]
         system_messages = build_system_messages(self.chat)
         messages = [self.message_transform(sm) for sm in system_messages] + messages
 
@@ -447,11 +496,16 @@ class OpenAIProvider(BaseProvider):
         if hasattr(self, "_get_auth_headers"):
             kwargs["extra_headers"] = await self._get_auth_headers()
 
+        # max_tokens is rejected by reasoning models (o-series, gpt-5);
+        # max_completion_tokens by some OpenAI-compatible gateways.
+        # AGENTLYS_OPENAI_LEGACY_MAX_TOKENS=1 keeps the old field for those.
+        if os.getenv("AGENTLYS_OPENAI_LEGACY_MAX_TOKENS") == "1":
+            kwargs["max_tokens"] = max_tokens
+        else:
+            kwargs["max_completion_tokens"] = max_tokens
         res = await self.client.chat.completions.create(
             model=model or self.model,
             messages=messages,
-            # max_tokens is rejected by reasoning models (o-series, gpt-5).
-            max_completion_tokens=max_tokens,
             **kwargs,
         )
         content = res.choices[0].message.content

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -98,6 +98,18 @@ def usage_to_dict(usage) -> typing.Optional[dict]:
         result["cache_read_input_tokens"] = cache_read
     if cache_creation:
         result["cache_creation_input_tokens"] = cache_creation
+    # Reasoning models report their hidden thinking as a subset of
+    # completion_tokens; keep it visible for cost attribution.
+    completion_details = getattr(usage, "completion_tokens_details", None)
+    reasoning = None
+    if completion_details is not None:
+        reasoning = (
+            completion_details.get("reasoning_tokens")
+            if isinstance(completion_details, dict)
+            else getattr(completion_details, "reasoning_tokens", None)
+        )
+    if reasoning:
+        result["reasoning_tokens"] = reasoning
     return result
 
 
@@ -144,7 +156,12 @@ def build_system_messages(chat: AgentlysBase) -> list[Message]:
     """System prompt as role="system" Messages (instruction, context, tool states)."""
     return [
         Message(role="system", content=text)
-        for text in (chat.instruction, chat.context, chat.initial_tools_states)
+        for text in (
+            chat.instruction,
+            chat.context,
+            chat.initial_tools_states,
+            chat.tool_search_categories_hint,
+        )
         if text
     ]
 
@@ -179,6 +196,27 @@ def parts_to_openai_dict(part: MessagePart) -> dict:
                 "url": f"data:{part.image.format};base64,{part.image.to_base64()}"
             },
         }
+    elif part.type == "document":
+        if part.document is None:
+            raise ValueError("Document part must have a document")
+        doc = part.document
+        if doc.media_type == "text/plain":
+            name = doc.name or "document"
+            text = doc.data.decode("utf-8", errors="replace")
+            return {"type": "text", "text": f"[Document: {name}]\n{text}"}
+        if doc.media_type == "application/pdf":
+            return {
+                "type": "file",
+                "file": {
+                    "filename": doc.name or "document.pdf",
+                    "file_data": f"data:application/pdf;base64,{doc.to_base64()}",
+                },
+            }
+        raise ValueError(
+            f"Unsupported document media_type {doc.media_type!r}: the Chat "
+            "Completions API accepts PDF files and inline text. Convert other "
+            "formats first."
+        )
     elif part.type == "compaction":
         return {
             "type": "text",
@@ -200,6 +238,11 @@ def message_to_openai_dict(message: Message) -> dict:
     else:
         res = {"role": message.role, "content": []}
         for part in message.parts:
+            if part.type == "thinking":
+                # Chat Completions has no reasoning-state item: a stored
+                # thinking block (Anthropic or Responses API) is simply
+                # not replayable here.
+                continue
             if part.type == "function_call" and message.role == "assistant":
                 res.setdefault("tool_calls", []).append(
                     {
@@ -282,10 +325,53 @@ class OpenAIProvider(BaseProvider):
         model: str,
         base_url: str = None,
         api_key: str = None,
+        effort: typing.Optional[str] = None,
+        # Accepted for config parity with AnthropicProvider: OpenAI-compatible
+        # APIs cache prompt prefixes on their own, there is nothing to set.
+        cache_ttl: typing.Optional[str] = None,
+        cache_ttl_messages: typing.Optional[str] = None,
     ):
+        from agentlys.providers.openai_responses import resolve_effort
+
         self.chat = chat
         self.model = model
+        self.effort = resolve_effort(effort)
         self.client = create_openai_client(base_url=base_url, api_key=api_key)
+
+    def _loaded_tool_names(self) -> set[str]:
+        """Tools a tool_search result has loaded so far in this conversation.
+
+        OpenAI-compatible APIs have no server-side deferred loading, so the
+        search tool's ``tool_references`` are honoured here: a deferred tool
+        is sent only once a search has surfaced it.
+        """
+        loaded: set[str] = set()
+        for message in self.chat.messages:
+            for part in message.parts:
+                if part.tool_references:
+                    loaded.update(part.tool_references)
+        return loaded
+
+    def _apply_reasoning_effort(self, kwargs: dict) -> None:
+        """Translate the effort / thinking settings into ``reasoning_effort``.
+
+        Per-call ``effort`` beats the provider default, which beats a
+        translated Anthropic-style ``thinking`` config. ``thinking`` itself
+        is never forwarded: the API rejects unknown parameters.
+        """
+        from agentlys.providers.openai_responses import (
+            resolve_effort,
+            thinking_to_effort,
+        )
+
+        thinking = kwargs.pop("thinking", None) or getattr(self.chat, "thinking", None)
+        effort = resolve_effort(kwargs.pop("effort", None)) or getattr(
+            self, "effort", None
+        )
+        if effort is None:
+            effort = thinking_to_effort(thinking)
+        if effort and "reasoning_effort" not in kwargs:
+            kwargs["reasoning_effort"] = effort
 
     def _prepare_request_params(self, **kwargs):
         """Prepare messages, tools, and kwargs for an OpenAI-compatible request."""
@@ -304,20 +390,22 @@ class OpenAIProvider(BaseProvider):
         if self.chat.use_tools_only and "tool_choice" not in kwargs:
             kwargs["tool_choice"] = "required"
 
+        self._apply_reasoning_effort(kwargs)
+
         tools = []
         if self.chat.functions_schema:
+            loaded = self._loaded_tool_names()
             for tool_schema in self.chat.functions_schema:
-                # Strip defer_loading from the function schema before sending
+                if (
+                    tool_schema.get("defer_loading")
+                    and tool_schema["name"] not in loaded
+                ):
+                    continue
+                # defer_loading is an agentlys-level flag, not an API field.
                 clean_schema = {
                     k: v for k, v in tool_schema.items() if k != "defer_loading"
                 }
-                tool_def = {
-                    "type": "function",
-                    "function": clean_schema,
-                }
-                if tool_schema.get("defer_loading"):
-                    tool_def["defer_loading"] = True
-                tools.append(tool_def)
+                tools.append({"type": "function", "function": clean_schema})
 
         return messages, tools, kwargs
 
@@ -362,7 +450,8 @@ class OpenAIProvider(BaseProvider):
         res = await self.client.chat.completions.create(
             model=model or self.model,
             messages=messages,
-            max_tokens=max_tokens,
+            # max_tokens is rejected by reasoning models (o-series, gpt-5).
+            max_completion_tokens=max_tokens,
             **kwargs,
         )
         content = res.choices[0].message.content
@@ -379,6 +468,12 @@ class OpenAIProvider(BaseProvider):
         messages, tools, kwargs = self._prepare_request_params(**kwargs)
         if tools:
             kwargs["tools"] = tools
+        # Streamed responses omit usage unless asked; without it the final
+        # Message has no token counts and compaction never triggers.
+        # AGENTLYS_OPENAI_STREAM_USAGE=0 opts out for gateways that reject
+        # stream_options.
+        if os.getenv("AGENTLYS_OPENAI_STREAM_USAGE", "1") != "0":
+            kwargs.setdefault("stream_options", {"include_usage": True})
 
         stream = await self.client.chat.completions.create(
             model=self.model,

--- a/src/agentlys/providers/openai_responses.py
+++ b/src/agentlys/providers/openai_responses.py
@@ -24,7 +24,11 @@ import typing
 from agentlys.base import AgentlysBase
 from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import BaseProvider
-from agentlys.providers.openai import OPENAI_DEFAULT_BASE_URL
+from agentlys.providers.openai import (
+    create_openai_client,
+    resolve_effort,
+    thinking_to_effort,
+)
 from agentlys.providers.utils import (
     FunctionCallParsingError,
     add_empty_function_result,
@@ -35,57 +39,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_OUTPUT_TOKENS = int(os.getenv("OPENAI_MAX_OUTPUT_TOKENS", "16000"))
 
-# reasoning.effort values the API accepts. Availability varies per model
-# generation (``minimal`` is gpt-5 only, ``none`` needs gpt-5.1+, ``xhigh``
-# gpt-5.2+); the provider forwards whatever it is given and lets the API
-# reject a value the target model does not support.
-_VALID_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh")
-
-# Anthropic ``output_config.effort`` levels that have no OpenAI namesake.
-_EFFORT_ALIASES = {"max": "xhigh"}
-
 _SIGNATURE_SEPARATOR = "|"
-
-
-def resolve_effort(value: typing.Optional[str]) -> typing.Optional[str]:
-    """Normalize an effort level to what the Responses API accepts.
-
-    Accepts the OpenAI levels as-is and translates the Anthropic-only ones,
-    so a caller can keep one ``effort=`` setting across providers.
-    """
-    effort = value or os.getenv("AGENTLYS_EFFORT") or None
-    if effort is None:
-        return None
-    effort = _EFFORT_ALIASES.get(effort, effort)
-    if effort not in _VALID_EFFORTS:
-        raise ValueError(
-            f"Invalid effort {effort!r}: expected one of {_VALID_EFFORTS} "
-            f"or {tuple(_EFFORT_ALIASES)}"
-        )
-    return effort
-
-
-def thinking_to_effort(thinking: typing.Optional[dict]) -> typing.Optional[str]:
-    """Map an Anthropic ``thinking`` config onto a reasoning effort.
-
-    ``adaptive`` (let the model decide) maps to "no effort sent", which is the
-    API's own adaptive default. ``enabled`` scales with the budget the caller
-    had in mind. ``disabled`` becomes ``low`` rather than ``none``/``minimal``
-    because neither of those exists on every reasoning model generation.
-    """
-    if not thinking:
-        return None
-    thinking_type = thinking.get("type")
-    if thinking_type == "disabled":
-        return "low"
-    if thinking_type == "enabled":
-        budget = thinking.get("budget_tokens") or 0
-        if budget < 2048:
-            return "low"
-        if budget < 8192:
-            return "medium"
-        return "high"
-    return None
 
 
 def encode_thinking_signature(item_id: typing.Optional[str], encrypted: str) -> str:
@@ -107,6 +61,14 @@ def decode_thinking_signature(
     return (item_id or None), (encrypted or None)
 
 
+def _get(obj, name, default=None):
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
 def usage_to_dict(usage) -> typing.Optional[dict]:
     """Normalize Responses usage to the naming used by Message.
 
@@ -119,18 +81,12 @@ def usage_to_dict(usage) -> typing.Optional[dict]:
     if usage is None:
         return None
 
-    def _get(obj, name, default=0):
-        if obj is None:
-            return default
-        value = obj.get(name) if isinstance(obj, dict) else getattr(obj, name, None)
-        return default if value is None else value
-
     input_tokens = _get(usage, "input_tokens") or 0
     output_tokens = _get(usage, "output_tokens") or 0
     cached = min(
-        _get(_get(usage, "input_tokens_details", None), "cached_tokens"), input_tokens
+        _get(_get(usage, "input_tokens_details"), "cached_tokens") or 0, input_tokens
     )
-    reasoning = _get(_get(usage, "output_tokens_details", None), "reasoning_tokens")
+    reasoning = _get(_get(usage, "output_tokens_details"), "reasoning_tokens")
 
     result = {
         "input_tokens": input_tokens - cached,
@@ -230,11 +186,11 @@ def message_to_responses_items(message: Message) -> list[dict]:
     if message.role == "assistant":
         keep_thinking = getattr(message, "is_live", False)
         items: list[dict] = []
-        text_parts: list[dict] = []
+        text_parts: list[str] = []
 
         def _flush_text():
             if text_parts:
-                items.append({"role": "assistant", "content": list(text_parts)})
+                items.append({"role": "assistant", "content": "".join(text_parts)})
                 text_parts.clear()
 
         for part in message.parts:
@@ -242,20 +198,21 @@ def message_to_responses_items(message: Message) -> list[dict]:
                 if not keep_thinking:
                     continue
                 item_id, encrypted = decode_thinking_signature(part.thinking_signature)
-                if not encrypted:
+                if not item_id or not encrypted:
                     continue
                 _flush_text()
-                item = {
-                    "type": "reasoning",
-                    "id": item_id,
-                    "summary": (
-                        [{"type": "summary_text", "text": part.thinking}]
-                        if part.thinking
-                        else []
-                    ),
-                    "encrypted_content": encrypted,
-                }
-                items.append(item)
+                items.append(
+                    {
+                        "type": "reasoning",
+                        "id": item_id,
+                        "summary": (
+                            [{"type": "summary_text", "text": part.thinking}]
+                            if part.thinking
+                            else []
+                        ),
+                        "encrypted_content": encrypted,
+                    }
+                )
             elif part.type == "function_call":
                 _flush_text()
                 items.append(
@@ -268,19 +225,18 @@ def message_to_responses_items(message: Message) -> list[dict]:
                 )
             elif part.type == "text":
                 if part.content and part.content.strip():
-                    text_parts.append({"type": "output_text", "text": part.content})
+                    text_parts.append(part.content)
             elif part.type == "compaction":
-                text_parts.append(
-                    {
-                        "type": "output_text",
-                        "text": f"[Previous conversation summary]\n{part.content}",
-                    }
-                )
+                text_parts.append(f"[Previous conversation summary]\n{part.content}")
             else:
-                # Images/documents never appear on assistant turns; be strict
-                # so a mis-built history fails here rather than at the API.
                 raise ValueError(f"Unsupported assistant part type: {part.type}")
         _flush_text()
+        # The API rejects a replayed reasoning item that is not followed by
+        # the item it originally preceded (a turn cut off by
+        # max_output_tokens, say): a trailing one would 400 every request
+        # from here on.
+        while items and items[-1].get("type") == "reasoning":
+            items.pop()
         return items
 
     # user (and any other role) -> a single message item
@@ -314,12 +270,15 @@ def message_to_responses_items(message: Message) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def _get(obj, name, default=None):
-    if obj is None:
-        return default
-    if isinstance(obj, dict):
-        return obj.get(name, default)
-    return getattr(obj, name, default)
+def _warn_if_incomplete(response) -> None:
+    if _get(response, "status") != "incomplete":
+        return
+    reason = _get(_get(response, "incomplete_details"), "reason")
+    logger.warning(
+        "OpenAI response %s is incomplete (%s): the turn was cut off",
+        _get(response, "id"),
+        reason,
+    )
 
 
 def output_to_message(
@@ -349,9 +308,9 @@ def output_to_message(
             )
         elif item_type == "message":
             text = "".join(
-                _get(c, "text", "")
+                _get(c, "text", "") or _get(c, "refusal", "")
                 for c in (_get(item, "content") or [])
-                if _get(c, "type") == "output_text"
+                if _get(c, "type") in ("output_text", "refusal")
             )
             if text.strip():
                 parts.append(MessagePart(type="text", content=text))
@@ -401,8 +360,6 @@ class OpenAIResponsesProvider(BaseProvider):
         cache_ttl: typing.Optional[str] = None,
         cache_ttl_messages: typing.Optional[str] = None,
     ):
-        from openai import AsyncOpenAI
-
         self.chat = chat
         self.model = model
         self.max_tokens = (
@@ -410,18 +367,8 @@ class OpenAIResponsesProvider(BaseProvider):
         )
         self.effort = resolve_effort(effort)
         self.reasoning_summary = reasoning_summary
-        env_host = os.getenv("AGENTLYS_HOST")
-        resolved_api_key = api_key or os.getenv("AGENTLYS_API_KEY")
-        if (
-            resolved_api_key is None
-            and (base_url or env_host)
-            and not os.getenv("OPENAI_API_KEY")
-        ):
-            resolved_api_key = "not-needed"
-        self.client = AsyncOpenAI(
-            base_url=base_url or env_host or OPENAI_DEFAULT_BASE_URL,
-            api_key=resolved_api_key,
-            default_headers=default_headers,
+        self.client = create_openai_client(
+            base_url=base_url, api_key=api_key, default_headers=default_headers
         )
 
     # -- request assembly ---------------------------------------------------
@@ -442,9 +389,10 @@ class OpenAIResponsesProvider(BaseProvider):
     def _loaded_tool_names(self) -> set[str]:
         """Tools a tool_search result has loaded so far in this conversation.
 
-        The Responses API has no server-side deferred loading, so the search
-        tool's ``tool_references`` are honoured here: a deferred tool is sent
-        only once a search has surfaced it.
+        The API's own deferral (``defer_loading`` + its ``tool_search`` tool)
+        would replace agentlys' search function; keeping the client-side
+        search, the search tool's ``tool_references`` are honoured here: a
+        deferred tool is sent only once a search has surfaced it.
         """
         loaded: set[str] = set()
         for message in self.chat.messages:
@@ -459,15 +407,18 @@ class OpenAIResponsesProvider(BaseProvider):
         for s in self.chat.functions_schema:
             if s.get("defer_loading") and s["name"] not in loaded:
                 continue
-            tool_def = {
-                "type": "function",
-                "name": s["name"],
-                "description": s.get("description") or "No description provided",
-                "parameters": s["parameters"],
-            }
-            if s.get("strict") is True:
-                tool_def["strict"] = True
-            tools.append(tool_def)
+            tools.append(
+                {
+                    "type": "function",
+                    "name": s["name"],
+                    "description": s.get("description") or "No description provided",
+                    "parameters": s["parameters"],
+                    # Unlike Chat Completions, the Responses API defaults
+                    # strict to true, which rejects any schema with an
+                    # optional argument.
+                    "strict": s.get("strict") is True,
+                }
+            )
         return tools
 
     def _build_reasoning(self, kwargs: dict) -> typing.Optional[dict]:
@@ -530,6 +481,7 @@ class OpenAIResponsesProvider(BaseProvider):
         res = await self.client.responses.create(
             model=self.model, input=input_items, **kwargs
         )
+        _warn_if_incomplete(res)
         return output_to_message(res.output, response_id=res.id, usage=res.usage)
 
     async def complete(
@@ -578,12 +530,21 @@ class OpenAIResponsesProvider(BaseProvider):
 
         # output_index -> {"name", "id"} for function_call items in flight
         current_tools: dict[int, dict] = {}
+        summary_parts: dict[int, int] = {}
         final_response = None
 
         async for event in stream:
             event_type = _get(event, "type")
             if event_type == "response.output_text.delta":
                 yield {"type": "text", "content": _get(event, "delta", "")}
+            elif event_type == "response.refusal.delta":
+                yield {"type": "text", "content": _get(event, "delta", "")}
+            elif event_type == "response.reasoning_summary_part.added":
+                index = _get(event, "output_index", 0)
+                if summary_parts.get(index):
+                    # Parts are joined with a blank line in the stored message.
+                    yield {"type": "thinking", "content": "\n\n"}
+                summary_parts[index] = summary_parts.get(index, 0) + 1
             elif event_type == "response.reasoning_summary_text.delta":
                 yield {"type": "thinking", "content": _get(event, "delta", "")}
             elif event_type == "response.output_item.added":
@@ -622,6 +583,7 @@ class OpenAIResponsesProvider(BaseProvider):
             raise RuntimeError(
                 f"OpenAI response failed: {_get(error, 'message') or error}"
             )
+        _warn_if_incomplete(final_response)
 
         final_message = output_to_message(
             _get(final_response, "output"),

--- a/src/agentlys/providers/openai_responses.py
+++ b/src/agentlys/providers/openai_responses.py
@@ -1,0 +1,631 @@
+"""OpenAI Responses API provider — GPT-5 / o-series with reasoning.
+
+Why a second OpenAI provider: the Chat Completions API cannot round-trip a
+reasoning model's hidden state between the turns of a tool loop, so every
+tool result restarts the model's thinking from scratch. The Responses API
+returns each turn's reasoning as an item whose ``encrypted_content`` we
+replay on the next request, the same way Anthropic thinking blocks travel
+with their signature.
+
+Reasoning is carried by the existing ``thinking`` MessagePart:
+
+- ``thinking``           → the reasoning summary text (may be empty)
+- ``thinking_signature`` → ``"<reasoning item id>|<encrypted_content>"``
+
+so callers that already persist thinking blocks for Anthropic (and reload
+them with ``load_messages(keep_thinking=True)``) need no schema change.
+"""
+
+import json
+import logging
+import os
+import typing
+
+from agentlys.base import AgentlysBase
+from agentlys.model import Message, MessagePart
+from agentlys.providers.base_provider import BaseProvider
+from agentlys.providers.openai import OPENAI_DEFAULT_BASE_URL
+from agentlys.providers.utils import (
+    FunctionCallParsingError,
+    add_empty_function_result,
+    drop_orphaned_function_results,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_OUTPUT_TOKENS = int(os.getenv("OPENAI_MAX_OUTPUT_TOKENS", "16000"))
+
+# reasoning.effort values the API accepts. Availability varies per model
+# generation (``minimal`` is gpt-5 only, ``none`` needs gpt-5.1+, ``xhigh``
+# gpt-5.2+); the provider forwards whatever it is given and lets the API
+# reject a value the target model does not support.
+_VALID_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh")
+
+# Anthropic ``output_config.effort`` levels that have no OpenAI namesake.
+_EFFORT_ALIASES = {"max": "xhigh"}
+
+_SIGNATURE_SEPARATOR = "|"
+
+
+def resolve_effort(value: typing.Optional[str]) -> typing.Optional[str]:
+    """Normalize an effort level to what the Responses API accepts.
+
+    Accepts the OpenAI levels as-is and translates the Anthropic-only ones,
+    so a caller can keep one ``effort=`` setting across providers.
+    """
+    effort = value or os.getenv("AGENTLYS_EFFORT") or None
+    if effort is None:
+        return None
+    effort = _EFFORT_ALIASES.get(effort, effort)
+    if effort not in _VALID_EFFORTS:
+        raise ValueError(
+            f"Invalid effort {effort!r}: expected one of {_VALID_EFFORTS} "
+            f"or {tuple(_EFFORT_ALIASES)}"
+        )
+    return effort
+
+
+def thinking_to_effort(thinking: typing.Optional[dict]) -> typing.Optional[str]:
+    """Map an Anthropic ``thinking`` config onto a reasoning effort.
+
+    ``adaptive`` (let the model decide) maps to "no effort sent", which is the
+    API's own adaptive default. ``enabled`` scales with the budget the caller
+    had in mind. ``disabled`` becomes ``low`` rather than ``none``/``minimal``
+    because neither of those exists on every reasoning model generation.
+    """
+    if not thinking:
+        return None
+    thinking_type = thinking.get("type")
+    if thinking_type == "disabled":
+        return "low"
+    if thinking_type == "enabled":
+        budget = thinking.get("budget_tokens") or 0
+        if budget < 2048:
+            return "low"
+        if budget < 8192:
+            return "medium"
+        return "high"
+    return None
+
+
+def encode_thinking_signature(item_id: typing.Optional[str], encrypted: str) -> str:
+    return f"{item_id or ''}{_SIGNATURE_SEPARATOR}{encrypted}"
+
+
+def decode_thinking_signature(
+    signature: typing.Optional[str],
+) -> tuple[typing.Optional[str], typing.Optional[str]]:
+    """Split a stored signature back into ``(item id, encrypted_content)``.
+
+    A signature without the separator is not ours (an Anthropic one, say)
+    and yields ``(None, None)`` so the block is skipped instead of replayed
+    to the wrong API.
+    """
+    if not signature or _SIGNATURE_SEPARATOR not in signature:
+        return None, None
+    item_id, encrypted = signature.split(_SIGNATURE_SEPARATOR, 1)
+    return (item_id or None), (encrypted or None)
+
+
+def usage_to_dict(usage) -> typing.Optional[dict]:
+    """Normalize Responses usage to the naming used by Message.
+
+    ``input_tokens`` is reported as the *total* prompt size with cached
+    tokens as a subset; Message uses Anthropic's split (``input_tokens`` =
+    uncached remainder) so ``compaction.should_compact`` sums one shape.
+    ``reasoning_tokens`` are a subset of ``output_tokens`` and are kept as an
+    extra field for cost attribution.
+    """
+    if usage is None:
+        return None
+
+    def _get(obj, name, default=0):
+        if obj is None:
+            return default
+        value = obj.get(name) if isinstance(obj, dict) else getattr(obj, name, None)
+        return default if value is None else value
+
+    input_tokens = _get(usage, "input_tokens") or 0
+    output_tokens = _get(usage, "output_tokens") or 0
+    cached = min(
+        _get(_get(usage, "input_tokens_details", None), "cached_tokens"), input_tokens
+    )
+    reasoning = _get(_get(usage, "output_tokens_details", None), "reasoning_tokens")
+
+    result = {
+        "input_tokens": input_tokens - cached,
+        "output_tokens": output_tokens,
+    }
+    if cached:
+        result["cache_read_input_tokens"] = cached
+    if reasoning:
+        result["reasoning_tokens"] = reasoning
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Message -> Responses input items
+# ---------------------------------------------------------------------------
+
+
+def _content_part(part: MessagePart) -> dict:
+    """Serialize a user-side content part (text, image, document)."""
+    if part.type == "text":
+        return {"type": "input_text", "text": part.content}
+    if part.type in ("image", "function_result_image"):
+        if part.image is None:
+            raise ValueError(f"{part.type} part must have an image")
+        return {
+            "type": "input_image",
+            "image_url": f"data:{part.image.format};base64,{part.image.to_base64()}",
+        }
+    if part.type == "document":
+        if part.document is None:
+            raise ValueError("Document part must have a document")
+        doc = part.document
+        if doc.media_type == "text/plain":
+            name = doc.name or "document"
+            text = doc.data.decode("utf-8", errors="replace")
+            return {"type": "input_text", "text": f"[Document: {name}]\n{text}"}
+        if doc.media_type == "application/pdf":
+            return {
+                "type": "input_file",
+                "filename": doc.name or "document.pdf",
+                "file_data": f"data:application/pdf;base64,{doc.to_base64()}",
+            }
+        raise ValueError(
+            f"Unsupported document media_type {doc.media_type!r}: the Responses "
+            "API accepts PDF files and inline text. Convert other formats first."
+        )
+    if part.type == "compaction":
+        return {
+            "type": "input_text",
+            "text": f"[Previous conversation summary]\n{part.content}",
+        }
+    if part.type == "function_result":
+        return {"type": "input_text", "text": part.content or ""}
+    raise ValueError(f"Unknown part type: {part.type}")
+
+
+def _function_result_output(parts: list[MessagePart]) -> typing.Union[str, list]:
+    """Build a ``function_call_output.output`` from one call's result parts.
+
+    Plain text stays a string (the common case, and the only form every
+    OpenAI-compatible gateway accepts); an image result switches to the
+    content-array form.
+    """
+    if all(p.type == "function_result" for p in parts):
+        return "\n".join(p.content or "" for p in parts)
+    output = []
+    for p in parts:
+        if p.type == "function_result_image":
+            if p.content:
+                output.append({"type": "input_text", "text": p.content})
+            output.append(_content_part(p))
+        else:
+            output.append(_content_part(p))
+    return output
+
+
+def message_to_responses_items(message: Message) -> list[dict]:
+    """Serialize one Message into Responses ``input`` items.
+
+    Assistant turns fan out into several items (reasoning, function_call,
+    message) because that is how the API models them; user turns collapse
+    into one message item.
+    """
+    if message.role == "function":
+        groups: dict[typing.Optional[str], list[MessagePart]] = {}
+        for part in message.parts:
+            groups.setdefault(part.function_call_id, []).append(part)
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": _function_result_output(parts),
+            }
+            for call_id, parts in groups.items()
+        ]
+
+    if message.role == "assistant":
+        keep_thinking = getattr(message, "is_live", False)
+        items: list[dict] = []
+        text_parts: list[dict] = []
+
+        def _flush_text():
+            if text_parts:
+                items.append({"role": "assistant", "content": list(text_parts)})
+                text_parts.clear()
+
+        for part in message.parts:
+            if part.type == "thinking":
+                if not keep_thinking:
+                    continue
+                item_id, encrypted = decode_thinking_signature(part.thinking_signature)
+                if not encrypted:
+                    continue
+                _flush_text()
+                item = {
+                    "type": "reasoning",
+                    "id": item_id,
+                    "summary": (
+                        [{"type": "summary_text", "text": part.thinking}]
+                        if part.thinking
+                        else []
+                    ),
+                    "encrypted_content": encrypted,
+                }
+                items.append(item)
+            elif part.type == "function_call":
+                _flush_text()
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": part.function_call_id,
+                        "name": part.function_call["name"],
+                        "arguments": json.dumps(part.function_call["arguments"]),
+                    }
+                )
+            elif part.type == "text":
+                if part.content and part.content.strip():
+                    text_parts.append({"type": "output_text", "text": part.content})
+            elif part.type == "compaction":
+                text_parts.append(
+                    {
+                        "type": "output_text",
+                        "text": f"[Previous conversation summary]\n{part.content}",
+                    }
+                )
+            else:
+                # Images/documents never appear on assistant turns; be strict
+                # so a mis-built history fails here rather than at the API.
+                raise ValueError(f"Unsupported assistant part type: {part.type}")
+        _flush_text()
+        return items
+
+    # user (and any other role) -> a single message item
+    role = (
+        "user" if message.role not in ("user", "system", "developer") else message.role
+    )
+    content = []
+    for part in message.parts:
+        if part.type == "thinking":
+            continue
+        if part.type == "function_call":
+            # A user-triggered tool call has no item form; spell it out.
+            content.append(
+                {
+                    "type": "input_text",
+                    "text": f"{part.function_call['name']}:"
+                    f"{json.dumps(part.function_call['arguments'])}",
+                }
+            )
+            continue
+        if part.type == "text" and (not part.content or not part.content.strip()):
+            continue
+        content.append(_content_part(part))
+    if not content:
+        return []
+    return [{"role": role, "content": content}]
+
+
+# ---------------------------------------------------------------------------
+# Responses output -> Message
+# ---------------------------------------------------------------------------
+
+
+def _get(obj, name, default=None):
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def output_to_message(
+    output: list,
+    response_id: typing.Optional[str] = None,
+    usage=None,
+) -> Message:
+    """Build the assistant Message from a response's ``output`` items."""
+    parts: list[MessagePart] = []
+    for item in output or []:
+        item_type = _get(item, "type")
+        if item_type == "reasoning":
+            summary = "\n\n".join(
+                _get(s, "text", "") for s in (_get(item, "summary") or [])
+            )
+            encrypted = _get(item, "encrypted_content")
+            parts.append(
+                MessagePart(
+                    type="thinking",
+                    thinking=summary or None,
+                    thinking_signature=(
+                        encode_thinking_signature(_get(item, "id"), encrypted)
+                        if encrypted
+                        else None
+                    ),
+                )
+            )
+        elif item_type == "message":
+            text = "".join(
+                _get(c, "text", "")
+                for c in (_get(item, "content") or [])
+                if _get(c, "type") == "output_text"
+            )
+            if text.strip():
+                parts.append(MessagePart(type="text", content=text))
+        elif item_type == "function_call":
+            raw_arguments = _get(item, "arguments") or "{}"
+            try:
+                arguments = json.loads(raw_arguments)
+            except json.decoder.JSONDecodeError:
+                raise FunctionCallParsingError(response_id, item)
+            parts.append(
+                MessagePart(
+                    type="function_call",
+                    function_call={"name": _get(item, "name"), "arguments": arguments},
+                    function_call_id=_get(item, "call_id"),
+                )
+            )
+        # Built-in tool items (web_search_call, ...) carry no replayable
+        # state we model; their results surface in the message text.
+
+    if not parts:
+        parts.append(MessagePart(type="text", content=""))
+    message = Message(role="assistant", parts=parts, id=response_id)
+    message.usage = usage_to_dict(usage)
+    # Produced by the API in this process: reasoning items are replayable.
+    message.is_live = True
+    return message
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class OpenAIResponsesProvider(BaseProvider):
+    def __init__(
+        self,
+        chat: AgentlysBase,
+        model: str,
+        base_url: typing.Optional[str] = None,
+        api_key: typing.Optional[str] = None,
+        max_tokens: typing.Optional[int] = None,
+        effort: typing.Optional[str] = None,
+        reasoning_summary: typing.Optional[str] = "auto",
+        default_headers: typing.Optional[dict] = None,
+        # Accepted for config parity with AnthropicProvider; OpenAI caches
+        # prompt prefixes automatically so there is nothing to configure.
+        cache_ttl: typing.Optional[str] = None,
+        cache_ttl_messages: typing.Optional[str] = None,
+    ):
+        from openai import AsyncOpenAI
+
+        self.chat = chat
+        self.model = model
+        self.max_tokens = (
+            DEFAULT_MAX_OUTPUT_TOKENS if max_tokens is None else max_tokens
+        )
+        self.effort = resolve_effort(effort)
+        self.reasoning_summary = reasoning_summary
+        env_host = os.getenv("AGENTLYS_HOST")
+        resolved_api_key = api_key or os.getenv("AGENTLYS_API_KEY")
+        if (
+            resolved_api_key is None
+            and (base_url or env_host)
+            and not os.getenv("OPENAI_API_KEY")
+        ):
+            resolved_api_key = "not-needed"
+        self.client = AsyncOpenAI(
+            base_url=base_url or env_host or OPENAI_DEFAULT_BASE_URL,
+            api_key=resolved_api_key,
+            default_headers=default_headers,
+        )
+
+    # -- request assembly ---------------------------------------------------
+
+    def _build_instructions(self) -> typing.Optional[str]:
+        blocks = [
+            text
+            for text in (
+                self.chat.instruction,
+                self.chat.context,
+                self.chat.initial_tools_states,
+                self.chat.tool_search_categories_hint,
+            )
+            if text
+        ]
+        return "\n\n".join(blocks) if blocks else None
+
+    def _loaded_tool_names(self) -> set[str]:
+        """Tools a tool_search result has loaded so far in this conversation.
+
+        The Responses API has no server-side deferred loading, so the search
+        tool's ``tool_references`` are honoured here: a deferred tool is sent
+        only once a search has surfaced it.
+        """
+        loaded: set[str] = set()
+        for message in self.chat.messages:
+            for part in message.parts:
+                if part.tool_references:
+                    loaded.update(part.tool_references)
+        return loaded
+
+    def _build_tools(self) -> list[dict]:
+        loaded = self._loaded_tool_names()
+        tools = []
+        for s in self.chat.functions_schema:
+            if s.get("defer_loading") and s["name"] not in loaded:
+                continue
+            tool_def = {
+                "type": "function",
+                "name": s["name"],
+                "description": s.get("description") or "No description provided",
+                "parameters": s["parameters"],
+            }
+            if s.get("strict") is True:
+                tool_def["strict"] = True
+            tools.append(tool_def)
+        return tools
+
+    def _build_reasoning(self, kwargs: dict) -> typing.Optional[dict]:
+        """Turn the effort / thinking settings into a ``reasoning`` block.
+
+        Precedence: per-call ``effort`` > provider ``effort`` > per-call or
+        chat-level ``thinking`` (translated). Anything already given as a
+        ``reasoning`` kwarg wins outright.
+        """
+        thinking = kwargs.pop("thinking", None) or getattr(self.chat, "thinking", None)
+        effort = resolve_effort(kwargs.pop("effort", None)) or self.effort
+        if effort is None:
+            effort = thinking_to_effort(thinking)
+        if "reasoning" in kwargs:
+            return kwargs.pop("reasoning")
+        reasoning = {}
+        if effort:
+            reasoning["effort"] = effort
+        if self.reasoning_summary:
+            reasoning["summary"] = self.reasoning_summary
+        return reasoning or None
+
+    def _prepare_request_params(self, **kwargs) -> tuple[list[dict], list[dict], dict]:
+        input_items: list[dict] = []
+        for items in self.prepare_messages(
+            transform_function=message_to_responses_items,
+            transform_list_function=lambda x: add_empty_function_result(
+                drop_orphaned_function_results(x)
+            ),
+        ):
+            input_items.extend(items)
+
+        tools = self._build_tools()
+
+        instructions = self._build_instructions()
+        if instructions and "instructions" not in kwargs:
+            kwargs["instructions"] = instructions
+
+        if self.chat.use_tools_only and "tool_choice" not in kwargs:
+            kwargs["tool_choice"] = "required"
+
+        reasoning = self._build_reasoning(kwargs)
+        if reasoning:
+            kwargs["reasoning"] = reasoning
+
+        kwargs.setdefault("store", False)
+        include = list(kwargs.get("include") or [])
+        if "reasoning.encrypted_content" not in include:
+            include.append("reasoning.encrypted_content")
+        kwargs["include"] = include
+        kwargs.setdefault("max_output_tokens", self.max_tokens)
+        return input_items, tools, kwargs
+
+    # -- API calls ----------------------------------------------------------
+
+    async def fetch_async(self, **kwargs) -> Message:
+        input_items, tools, kwargs = self._prepare_request_params(**kwargs)
+        if tools:
+            kwargs["tools"] = tools
+        res = await self.client.responses.create(
+            model=self.model, input=input_items, **kwargs
+        )
+        return output_to_message(res.output, response_id=res.id, usage=res.usage)
+
+    async def complete(
+        self,
+        messages: list[dict],
+        system: typing.Optional[str] = None,
+        model: typing.Optional[str] = None,
+        max_tokens: int = 4096,
+    ) -> str:
+        kwargs: dict = {"store": False}
+        if system:
+            kwargs["instructions"] = system
+        if hasattr(self, "_get_auth_headers"):
+            kwargs["extra_headers"] = await self._get_auth_headers()
+        res = await self.client.responses.create(
+            model=model or self.model,
+            input=messages,
+            max_output_tokens=max_tokens,
+            **kwargs,
+        )
+        text = getattr(res, "output_text", None) or "".join(
+            _get(c, "text", "")
+            for item in (res.output or [])
+            if _get(item, "type") == "message"
+            for c in (_get(item, "content") or [])
+            if _get(c, "type") == "output_text"
+        )
+        if not text:
+            raise RuntimeError("Completion response contained no text")
+        return text
+
+    async def fetch_stream_async(self, **kwargs):
+        """Stream a response.
+
+        Yields ``text`` and ``thinking`` deltas like the Anthropic provider,
+        plus ``tool_started`` / ``tool_delta`` events for tool calls, then the
+        final ``message``.
+        """
+        input_items, tools, kwargs = self._prepare_request_params(**kwargs)
+        if tools:
+            kwargs["tools"] = tools
+
+        stream = await self.client.responses.create(
+            model=self.model, input=input_items, stream=True, **kwargs
+        )
+
+        # output_index -> {"name", "id"} for function_call items in flight
+        current_tools: dict[int, dict] = {}
+        final_response = None
+
+        async for event in stream:
+            event_type = _get(event, "type")
+            if event_type == "response.output_text.delta":
+                yield {"type": "text", "content": _get(event, "delta", "")}
+            elif event_type == "response.reasoning_summary_text.delta":
+                yield {"type": "thinking", "content": _get(event, "delta", "")}
+            elif event_type == "response.output_item.added":
+                item = _get(event, "item")
+                if _get(item, "type") == "function_call":
+                    index = _get(event, "output_index", 0)
+                    info = {"name": _get(item, "name"), "id": _get(item, "call_id")}
+                    current_tools[index] = info
+                    yield {
+                        "type": "tool_started",
+                        "name": info["name"],
+                        "id": info["id"],
+                        "index": index,
+                    }
+            elif event_type == "response.function_call_arguments.delta":
+                info = current_tools.get(_get(event, "output_index", 0), {})
+                yield {
+                    "type": "tool_delta",
+                    "name": info.get("name"),
+                    "id": info.get("id"),
+                    "partial_json": _get(event, "delta", ""),
+                }
+            elif event_type == "response.completed":
+                final_response = _get(event, "response")
+            elif event_type in ("response.failed", "response.incomplete"):
+                final_response = _get(event, "response")
+            elif event_type == "error":
+                raise RuntimeError(
+                    f"OpenAI stream error: {_get(event, 'message') or event}"
+                )
+
+        if final_response is None:
+            raise RuntimeError("Stream ended without a completed response")
+        error = _get(final_response, "error")
+        if error:
+            raise RuntimeError(
+                f"OpenAI response failed: {_get(error, 'message') or error}"
+            )
+
+        final_message = output_to_message(
+            _get(final_response, "output"),
+            response_id=_get(final_response, "id"),
+            usage=_get(final_response, "usage"),
+        )
+        yield {"type": "message", "message": final_message}

--- a/src/agentlys/providers/utils.py
+++ b/src/agentlys/providers/utils.py
@@ -69,6 +69,12 @@ def get_provider_and_model(  # TODO: get_provider_and_model ?
         if not model:
             model = os.getenv("AGENTLYS_MODEL", "gpt-4o")
         return OpenAIProvider(chat, model=model, **client_kwargs), model
+    elif provider_key == APIProvider.OPENAI_RESPONSES:
+        from agentlys.providers.openai_responses import OpenAIResponsesProvider
+
+        if not model:
+            model = os.getenv("AGENTLYS_MODEL", "gpt-5.4")
+        return OpenAIResponsesProvider(chat, model=model, **client_kwargs), model
     elif provider_key == APIProvider.ANTHROPIC:
         from agentlys.providers.anthropic import AnthropicProvider
 

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -1042,3 +1042,28 @@ class TestDocumentParts(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_openai_reasoning_signature_is_not_replayed_to_anthropic():
+    """A conversation that ran on the OpenAI Responses provider carries
+    reasoning in thinking parts signed "<id>|<encrypted>"; switching the
+    provider back to Anthropic must drop them instead of sending an invalid
+    signature (400)."""
+    from agentlys.providers.anthropic import message_to_anthropic_dict
+
+    message = Message(
+        role="assistant",
+        parts=[
+            MessagePart(
+                type="thinking", thinking="plan", thinking_signature="rs_1|ENC"
+            ),
+            MessagePart(
+                type="thinking", thinking="plan", thinking_signature="ErUBCkYIBRgC"
+            ),
+            MessagePart(type="text", content="ok"),
+        ],
+    )
+    message.is_live = True
+    content = message_to_anthropic_dict(message)["content"]
+    assert [block["type"] for block in content] == ["thinking", "text"]
+    assert content[0]["signature"] == "ErUBCkYIBRgC"

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -459,7 +459,7 @@ class TestCompleteAndCompaction:
         # The agent instruction rides along as the system message
         kwargs = mock_create.call_args.kwargs
         assert kwargs["messages"][0]["role"] == "system"
-        assert kwargs["max_tokens"] == 4096
+        assert kwargs["max_completion_tokens"] == 4096
 
     @pytest.mark.asyncio
     async def test_complete_not_implemented_on_bare_provider(self):
@@ -652,3 +652,189 @@ class TestUsageToDict:
         result = usage_to_dict(usage)
         assert result["input_tokens"] == 0
         assert result["cache_read_input_tokens"] == 100
+
+
+class TestReasoningModelCompat:
+    """GPT-5 / o-series specifics on the Chat Completions path."""
+
+    def _agent(self, **kwargs):
+        agent = Agentlys(provider="openai", model="gpt-5.4", **kwargs)
+        calls = []
+
+        async def create(**kw):
+            calls.append(kw)
+            return SimpleNamespace(
+                id="chatcmpl-1",
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            role="assistant", content="ok", tool_calls=None
+                        )
+                    )
+                ],
+                usage=None,
+            )
+
+        agent.provider.client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+        )
+        return agent, calls
+
+    @pytest.mark.asyncio
+    async def test_effort_becomes_reasoning_effort(self):
+        agent, calls = self._agent(effort="max")
+        await agent.ask_async("hi")
+        assert calls[0]["reasoning_effort"] == "xhigh"
+        assert "effort" not in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_thinking_is_translated_not_forwarded(self):
+        agent, calls = self._agent(
+            thinking={"type": "enabled", "budget_tokens": 1000}, cache_ttl="1h"
+        )
+        await agent.ask_async("hi")
+        assert "thinking" not in calls[0]
+        assert calls[0]["reasoning_effort"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_no_effort_sends_nothing(self):
+        agent, calls = self._agent()
+        await agent.ask_async("hi")
+        assert "reasoning_effort" not in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_deferred_tools_hidden_and_flag_stripped(self):
+        agent, calls = self._agent()
+
+        def get_weather(city: str) -> str:
+            """Weather forecast.
+
+            Args:
+                city: the city
+            """
+            return "sunny"
+
+        agent.add_function(get_weather)
+        agent.enable_tool_search()
+        await agent.ask_async("hi")
+        tools = calls[0]["tools"]
+        assert [t["function"]["name"] for t in tools] == ["tool_search"]
+        assert all(
+            "defer_loading" not in t and "defer_loading" not in t["function"]
+            for t in tools
+        )
+        system = [m for m in calls[0]["messages"] if m["role"] == "system"]
+        assert any("get_weather" in json.dumps(m["content"]) for m in system)
+
+        # A search result loads the tool for the next request.
+        agent.messages.append(
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="function_call",
+                        function_call={
+                            "name": "tool_search",
+                            "arguments": {"query": "weather"},
+                        },
+                        function_call_id="call_s",
+                    )
+                ],
+            )
+        )
+        agent.messages.append(
+            Message(
+                role="function",
+                parts=[
+                    MessagePart(
+                        type="function_result",
+                        content="get_weather",
+                        function_call_id="call_s",
+                        tool_references=["get_weather"],
+                    )
+                ],
+            )
+        )
+        await agent.ask_async(None)
+        assert {t["function"]["name"] for t in calls[1]["tools"]} == {
+            "tool_search",
+            "get_weather",
+        }
+
+    def test_thinking_part_is_skipped(self):
+        message = Message(
+            role="assistant",
+            parts=[
+                MessagePart(type="thinking", thinking="t", thinking_signature="sig"),
+                MessagePart(type="text", content="hello"),
+            ],
+        )
+        assert message_to_openai_dict(message)["content"] == [
+            {"type": "text", "text": "hello"}
+        ]
+
+    def test_pdf_document_part(self):
+        from agentlys.model import Document
+
+        message = Message(
+            role="user",
+            parts=[
+                MessagePart(type="document", document=Document(b"%PDF", name="a.pdf")),
+            ],
+        )
+        [part] = message_to_openai_dict(message)["content"]
+        assert part["type"] == "file"
+        assert part["file"]["filename"] == "a.pdf"
+
+    def test_usage_reasoning_tokens(self):
+        usage = SimpleNamespace(
+            prompt_tokens=100,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+            completion_tokens=30,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=12),
+        )
+        assert usage_to_dict(usage) == {
+            "input_tokens": 60,
+            "output_tokens": 30,
+            "cache_read_input_tokens": 40,
+            "reasoning_tokens": 12,
+        }
+
+    @pytest.mark.asyncio
+    async def test_stream_requests_usage(self):
+        agent = Agentlys(provider="openai", model="gpt-5.4")
+        calls = []
+
+        class _Iter:
+            def __init__(self):
+                self.items = [
+                    SimpleNamespace(
+                        id="c",
+                        choices=[],
+                        usage=SimpleNamespace(
+                            prompt_tokens=5,
+                            prompt_tokens_details=None,
+                            completion_tokens=1,
+                            completion_tokens_details=None,
+                        ),
+                    )
+                ]
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self.items:
+                    raise StopAsyncIteration
+                return self.items.pop(0)
+
+        async def create(**kw):
+            calls.append(kw)
+            return _Iter()
+
+        agent.provider.client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+        )
+        chunks = [c async for c in agent.ask_stream_async("hi")]
+        assert calls[0]["stream_options"] == {"include_usage": True}
+        assert chunks[-1]["message"].usage == {"input_tokens": 5, "output_tokens": 1}

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -697,6 +697,41 @@ class TestReasoningModelCompat:
         assert calls[0]["reasoning_effort"] == "low"
 
     @pytest.mark.asyncio
+    async def test_disabled_thinking_sends_no_effort(self):
+        # gpt-4o and OpenAI-compatible models reject reasoning_effort.
+        agent, calls = self._agent(thinking={"type": "disabled"})
+        await agent.ask_async("hi")
+        assert "reasoning_effort" not in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_thinking_only_assistant_turn_is_dropped(self):
+        agent, calls = self._agent()
+        agent.messages.append(Message(role="user", content="hi"))
+        agent.messages.append(
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(type="thinking", thinking="t", thinking_signature="s")
+                ],
+            )
+        )
+        await agent.ask_async("again")
+        assert all(
+            m.get("content") or m.get("tool_calls")
+            for m in calls[0]["messages"]
+            if m["role"] == "assistant"
+        )
+
+    @pytest.mark.asyncio
+    async def test_legacy_max_tokens_opt_out(self, monkeypatch):
+        monkeypatch.setenv("AGENTLYS_OPENAI_LEGACY_MAX_TOKENS", "1")
+        agent, calls = self._agent()
+        await agent.provider.complete([{"role": "user", "content": "x"}])
+        assert (
+            calls[0]["max_tokens"] == 4096 and "max_completion_tokens" not in calls[0]
+        )
+
+    @pytest.mark.asyncio
     async def test_no_effort_sends_nothing(self):
         agent, calls = self._agent()
         await agent.ask_async("hi")

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -1,0 +1,731 @@
+"""Tests for the OpenAI Responses API provider (GPT-5 / o-series reasoning).
+
+No network: a fake client records the request and replays canned
+``responses.create`` results shaped like the real SDK objects.
+"""
+
+from types import SimpleNamespace as NS
+
+import pytest
+from agentlys import Agentlys
+from agentlys.model import Document, Message, MessagePart
+from agentlys.providers.openai_responses import (
+    OpenAIResponsesProvider,
+    decode_thinking_signature,
+    encode_thinking_signature,
+    message_to_responses_items,
+    output_to_message,
+    resolve_effort,
+    thinking_to_effort,
+    usage_to_dict,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (
+        "AGENTLYS_HOST",
+        "AGENTLYS_API_KEY",
+        "AGENTLYS_PROVIDER",
+        "AGENTLYS_EFFORT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+
+
+def _usage(input_tokens=100, cached=0, output_tokens=20, reasoning=0):
+    return NS(
+        input_tokens=input_tokens,
+        input_tokens_details=NS(cached_tokens=cached),
+        output_tokens=output_tokens,
+        output_tokens_details=NS(reasoning_tokens=reasoning),
+        total_tokens=input_tokens + output_tokens,
+    )
+
+
+def _reasoning_item(item_id="rs_1", text="thinking hard", encrypted="ENC"):
+    return NS(
+        type="reasoning",
+        id=item_id,
+        summary=[NS(type="summary_text", text=text)] if text else [],
+        encrypted_content=encrypted,
+    )
+
+
+def _message_item(text):
+    return NS(
+        type="message",
+        id="msg_1",
+        role="assistant",
+        content=[NS(type="output_text", text=text)],
+    )
+
+
+def _function_call_item(
+    call_id="call_1", name="get_weather", arguments='{"city": "Paris"}'
+):
+    return NS(
+        type="function_call", id="fc_1", call_id=call_id, name=name, arguments=arguments
+    )
+
+
+def _response(output, response_id="resp_1", usage=None):
+    return NS(
+        id=response_id,
+        output=output,
+        usage=usage or _usage(),
+        output_text="".join(
+            c.text
+            for i in output
+            if getattr(i, "type", None) == "message"
+            for c in i.content
+        ),
+        error=None,
+    )
+
+
+class FakeResponses:
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        result = self.results.pop(0)
+        if kwargs.get("stream"):
+            return _AsyncIter(result)
+        return result
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self.items:
+            raise StopAsyncIteration
+        return self.items.pop(0)
+
+
+def _agent(results, **kwargs):
+    agent = Agentlys(provider="openai_responses", model="gpt-5.4", **kwargs)
+    fake = FakeResponses(results)
+    agent.provider.client = NS(responses=fake)
+    return agent, fake
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_provider_selected_by_name(self):
+        agent = Agentlys(provider="openai_responses", model="gpt-5.4")
+        assert isinstance(agent.provider, OpenAIResponsesProvider)
+        assert str(agent.provider.client.base_url) == "https://api.openai.com/v1/"
+
+    def test_default_model(self):
+        agent = Agentlys(provider="openai_responses")
+        assert agent.provider.model == "gpt-5.4"
+
+    def test_anthropic_style_kwargs_are_accepted(self):
+        # The same Agentlys(...) call must work whichever provider is behind it.
+        agent = Agentlys(
+            provider="openai_responses",
+            model="gpt-5.4",
+            effort="max",
+            cache_ttl="1h",
+            cache_ttl_messages="1h",
+            thinking={"type": "adaptive"},
+        )
+        assert agent.provider.effort == "xhigh"
+
+    def test_invalid_effort(self):
+        with pytest.raises(ValueError):
+            Agentlys(provider="openai_responses", model="gpt-5.4", effort="turbo")
+
+    def test_custom_base_url_and_headers(self):
+        agent = Agentlys(provider="openai_responses", model="gpt-5.4")
+        provider = OpenAIResponsesProvider(
+            agent,
+            model="gpt-5.4",
+            base_url="http://proxy.local/ai/v1",
+            api_key="session-token",
+            default_headers={"X-Purpose": "chat"},
+        )
+        assert str(provider.client.base_url) == "http://proxy.local/ai/v1/"
+        assert provider.client.api_key == "session-token"
+        assert provider.client.default_headers["X-Purpose"] == "chat"
+
+
+# ---------------------------------------------------------------------------
+# Effort / thinking mapping
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningMapping:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, None),
+            ("low", "low"),
+            ("high", "high"),
+            ("xhigh", "xhigh"),
+            ("max", "xhigh"),
+            ("none", "none"),
+        ],
+    )
+    def test_resolve_effort(self, value, expected):
+        assert resolve_effort(value) == expected
+
+    @pytest.mark.parametrize(
+        "thinking, expected",
+        [
+            (None, None),
+            ({"type": "adaptive"}, None),
+            ({"type": "disabled"}, "low"),
+            ({"type": "enabled", "budget_tokens": 1024}, "low"),
+            ({"type": "enabled", "budget_tokens": 5000}, "medium"),
+            ({"type": "enabled", "budget_tokens": 16000}, "high"),
+        ],
+    )
+    def test_thinking_to_effort(self, thinking, expected):
+        assert thinking_to_effort(thinking) == expected
+
+    @pytest.mark.asyncio
+    async def test_reasoning_block_from_provider_effort(self):
+        agent, fake = _agent([_response([_message_item("hi")])], effort="high")
+        await agent.ask_async("hello")
+        assert fake.calls[0]["reasoning"] == {"effort": "high", "summary": "auto"}
+
+    @pytest.mark.asyncio
+    async def test_chat_thinking_translated_and_not_leaked(self):
+        agent, fake = _agent(
+            [_response([_message_item("hi")])],
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        )
+        await agent.ask_async("hello")
+        call = fake.calls[0]
+        assert "thinking" not in call
+        assert call["reasoning"]["effort"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_per_call_effort_wins(self):
+        agent, fake = _agent([_response([_message_item("hi")])], effort="low")
+        await agent.ask_async("hello", effort="high")
+        assert fake.calls[0]["reasoning"]["effort"] == "high"
+        assert "effort" not in fake.calls[0]
+
+    @pytest.mark.asyncio
+    async def test_adaptive_sends_summary_only(self):
+        agent, fake = _agent(
+            [_response([_message_item("hi")])], thinking={"type": "adaptive"}
+        )
+        await agent.ask_async("hello")
+        assert fake.calls[0]["reasoning"] == {"summary": "auto"}
+
+    @pytest.mark.asyncio
+    async def test_request_defaults(self):
+        agent, fake = _agent([_response([_message_item("hi")])])
+        agent.instruction = "Be terse."
+        await agent.ask_async("hello")
+        call = fake.calls[0]
+        assert call["store"] is False
+        assert call["include"] == ["reasoning.encrypted_content"]
+        assert call["instructions"] == "Be terse."
+        assert call["max_output_tokens"] == agent.provider.max_tokens
+        assert "max_tokens" not in call
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_user_text_and_image(self):
+        from PIL import Image as PILImage
+
+        image = PILImage.new("RGB", (2, 2))
+        image.format = "PNG"
+        message = Message(
+            role="user",
+            parts=[
+                MessagePart(type="text", content="look"),
+                MessagePart(type="image", image=image),
+            ],
+        )
+        [item] = message_to_responses_items(message)
+        assert item["role"] == "user"
+        assert item["content"][0] == {"type": "input_text", "text": "look"}
+        assert item["content"][1]["type"] == "input_image"
+        assert item["content"][1]["image_url"].startswith("data:image/png;base64,")
+
+    def test_pdf_document(self):
+        doc = Document(b"%PDF-1.4", name="report.pdf")
+        message = Message(
+            role="user", parts=[MessagePart(type="document", document=doc)]
+        )
+        [item] = message_to_responses_items(message)
+        assert item["content"][0]["type"] == "input_file"
+        assert item["content"][0]["filename"] == "report.pdf"
+        assert item["content"][0]["file_data"].startswith(
+            "data:application/pdf;base64,"
+        )
+
+    def test_text_document_inlined(self):
+        doc = Document(b"hello", media_type="text/plain", name="notes.txt")
+        message = Message(
+            role="user", parts=[MessagePart(type="document", document=doc)]
+        )
+        [item] = message_to_responses_items(message)
+        assert item["content"][0] == {
+            "type": "input_text",
+            "text": "[Document: notes.txt]\nhello",
+        }
+
+    def test_assistant_with_live_reasoning_and_tool_call(self):
+        message = Message(
+            role="assistant",
+            parts=[
+                MessagePart(
+                    type="thinking",
+                    thinking="plan",
+                    thinking_signature=encode_thinking_signature("rs_1", "ENC"),
+                ),
+                MessagePart(type="text", content="Let me check."),
+                MessagePart(
+                    type="function_call",
+                    function_call={"name": "f", "arguments": {"a": 1}},
+                    function_call_id="call_1",
+                ),
+            ],
+        )
+        message.is_live = True
+        items = message_to_responses_items(message)
+        assert items[0] == {
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [{"type": "summary_text", "text": "plan"}],
+            "encrypted_content": "ENC",
+        }
+        assert items[1] == {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Let me check."}],
+        }
+        assert items[2] == {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "f",
+            "arguments": '{"a": 1}',
+        }
+
+    def test_reasoning_dropped_when_not_live(self):
+        message = Message(
+            role="assistant",
+            parts=[
+                MessagePart(
+                    type="thinking",
+                    thinking="plan",
+                    thinking_signature=encode_thinking_signature("rs_1", "ENC"),
+                ),
+                MessagePart(type="text", content="ok"),
+            ],
+        )
+        items = message_to_responses_items(message)
+        assert [i.get("type", "message") for i in items] == ["message"]
+
+    def test_anthropic_signature_is_skipped_not_replayed(self):
+        # A history produced under Anthropic carries opaque signatures; they
+        # must not be sent to OpenAI as encrypted reasoning.
+        message = Message(
+            role="assistant",
+            parts=[
+                MessagePart(
+                    type="thinking",
+                    thinking="plan",
+                    thinking_signature="ErUBCkYIBRgC...",
+                ),
+                MessagePart(type="text", content="ok"),
+            ],
+        )
+        message.is_live = True
+        items = message_to_responses_items(message)
+        assert all(i.get("type") != "reasoning" for i in items)
+
+    def test_signature_roundtrip(self):
+        assert decode_thinking_signature(
+            encode_thinking_signature("rs_9", "abc|def")
+        ) == ("rs_9", "abc|def")
+        assert decode_thinking_signature(None) == (None, None)
+        assert decode_thinking_signature("opaque") == (None, None)
+
+    def test_function_results_one_output_per_call(self):
+        message = Message(
+            role="function",
+            parts=[
+                MessagePart(
+                    type="function_result", content="r1", function_call_id="c1"
+                ),
+                MessagePart(
+                    type="function_result", content="r2", function_call_id="c2"
+                ),
+            ],
+        )
+        items = message_to_responses_items(message)
+        assert items == [
+            {"type": "function_call_output", "call_id": "c1", "output": "r1"},
+            {"type": "function_call_output", "call_id": "c2", "output": "r2"},
+        ]
+
+    def test_function_result_image_uses_content_array(self):
+        from PIL import Image as PILImage
+
+        image = PILImage.new("RGB", (2, 2))
+        image.format = "PNG"
+        message = Message(
+            role="function",
+            parts=[
+                MessagePart(
+                    type="function_result_image",
+                    content="chart",
+                    image=image,
+                    function_call_id="c1",
+                ),
+            ],
+        )
+        [item] = message_to_responses_items(message)
+        assert item["output"][0] == {"type": "input_text", "text": "chart"}
+        assert item["output"][1]["type"] == "input_image"
+
+    def test_compaction_part(self):
+        message = Message(
+            role="user", parts=[MessagePart(type="compaction", content="summary")]
+        )
+        [item] = message_to_responses_items(message)
+        assert item["content"][0]["text"].startswith("[Previous conversation summary]")
+
+
+# ---------------------------------------------------------------------------
+# Output parsing / usage
+# ---------------------------------------------------------------------------
+
+
+class TestOutputParsing:
+    def test_reasoning_text_and_tool_call(self):
+        message = output_to_message(
+            [_reasoning_item(), _message_item("hello"), _function_call_item()],
+            response_id="resp_7",
+            usage=_usage(input_tokens=1000, cached=600, output_tokens=50, reasoning=30),
+        )
+        assert message.is_live is True
+        assert message.id == "resp_7"
+        assert [p.type for p in message.parts] == ["thinking", "text", "function_call"]
+        thinking = message.parts[0]
+        assert thinking.thinking == "thinking hard"
+        assert thinking.thinking_signature == "rs_1|ENC"
+        assert message.parts[2].function_call == {
+            "name": "get_weather",
+            "arguments": {"city": "Paris"},
+        }
+        assert message.parts[2].function_call_id == "call_1"
+        assert message.usage == {
+            "input_tokens": 400,
+            "output_tokens": 50,
+            "cache_read_input_tokens": 600,
+            "reasoning_tokens": 30,
+        }
+
+    def test_reasoning_without_summary_keeps_signature(self):
+        message = output_to_message([_reasoning_item(text=""), _message_item("x")])
+        assert message.parts[0].thinking is None
+        assert message.parts[0].thinking_signature == "rs_1|ENC"
+
+    def test_usage_none(self):
+        assert usage_to_dict(None) is None
+
+    def test_usage_dict_input(self):
+        assert usage_to_dict({"input_tokens": 10, "output_tokens": 5}) == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tool loop (non-streaming) with reasoning replay
+# ---------------------------------------------------------------------------
+
+
+class TestToolLoop:
+    @pytest.mark.asyncio
+    async def test_reasoning_replayed_on_next_turn(self):
+        agent, fake = _agent(
+            [
+                _response([_reasoning_item(), _function_call_item()], response_id="r1"),
+                _response(
+                    [_reasoning_item("rs_2", "done", "ENC2"), _message_item("21C")],
+                    response_id="r2",
+                ),
+            ]
+        )
+
+        def get_weather(city: str) -> str:
+            """Weather.
+
+            Args:
+                city: the city
+            """
+            return "21C sunny"
+
+        agent.add_function(get_weather)
+        messages = [m async for m in agent.run_conversation_async("Paris?")]
+        assert messages[-1].content == "21C"
+
+        second = fake.calls[1]
+        types = [i.get("type", "message") for i in second["input"]]
+        assert types == [
+            "message",
+            "reasoning",
+            "function_call",
+            "function_call_output",
+        ]
+        assert second["input"][1]["encrypted_content"] == "ENC"
+        assert second["input"][3] == {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "21C sunny",
+        }
+        tool = second["tools"][0]
+        assert tool["type"] == "function" and tool["name"] == "get_weather"
+        assert "defer_loading" not in tool
+
+    @pytest.mark.asyncio
+    async def test_use_tools_only(self):
+        agent, fake = _agent([_response([_message_item("x")])], use_tools_only=True)
+        await agent.ask_async("go")
+        assert fake.calls[0]["tool_choice"] == "required"
+
+    @pytest.mark.asyncio
+    async def test_load_messages_keep_thinking_replays(self):
+        agent, fake = _agent([_response([_message_item("x")])])
+        history = [
+            Message(role="user", content="hi"),
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="thinking", thinking="t", thinking_signature="rs_1|ENC"
+                    ),
+                    MessagePart(type="text", content="hello"),
+                ],
+            ),
+        ]
+        agent.load_messages(history, keep_thinking=True)
+        await agent.ask_async("again")
+        types = [i.get("type", "message") for i in fake.calls[0]["input"]]
+        assert types == ["message", "reasoning", "message", "message"]
+
+    @pytest.mark.asyncio
+    async def test_load_messages_default_strips_thinking(self):
+        agent, fake = _agent([_response([_message_item("x")])])
+        history = [
+            Message(role="user", content="hi"),
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="thinking", thinking="t", thinking_signature="rs_1|ENC"
+                    ),
+                    MessagePart(type="text", content="hello"),
+                ],
+            ),
+        ]
+        agent.load_messages(history)
+        await agent.ask_async("again")
+        assert all(i.get("type") != "reasoning" for i in fake.calls[0]["input"])
+
+
+# ---------------------------------------------------------------------------
+# Tool search emulation
+# ---------------------------------------------------------------------------
+
+
+class TestToolSearch:
+    @pytest.mark.asyncio
+    async def test_deferred_tools_hidden_until_searched(self):
+        agent, fake = _agent(
+            [
+                _response(
+                    [
+                        _function_call_item(
+                            "call_s", "tool_search", '{"query": "weather forecast"}'
+                        )
+                    ]
+                ),
+                _response(
+                    [_function_call_item("call_w", "get_weather", '{"city": "Rome"}')]
+                ),
+                _response([_message_item("done")]),
+            ]
+        )
+
+        def get_weather(city: str) -> str:
+            """Get the weather forecast for a city.
+
+            Args:
+                city: the city
+            """
+            return "sunny"
+
+        def get_stock(symbol: str) -> str:
+            """Get a stock price.
+
+            Args:
+                symbol: ticker
+            """
+            return "100"
+
+        agent.add_function(get_weather)
+        agent.add_function(get_stock)
+        agent.enable_tool_search()
+
+        [m async for m in agent.run_conversation_async("Weather in Rome?")]
+
+        first_tools = {t["name"] for t in fake.calls[0]["tools"]}
+        assert first_tools == {"tool_search"}
+        assert "get_weather" in fake.calls[0]["instructions"]  # categories hint
+        second_tools = {t["name"] for t in fake.calls[1]["tools"]}
+        assert second_tools == {"tool_search", "get_weather"}
+        assert all("defer_loading" not in t for t in fake.calls[1]["tools"])
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+def _stream_events(final):
+    return [
+        NS(type="response.created", response=NS(id="resp_s")),
+        NS(
+            type="response.output_item.added",
+            output_index=0,
+            item=NS(type="reasoning", id="rs_1"),
+        ),
+        NS(type="response.reasoning_summary_text.delta", delta="thin", output_index=0),
+        NS(type="response.reasoning_summary_text.delta", delta="king", output_index=0),
+        NS(
+            type="response.output_item.added",
+            output_index=1,
+            item=NS(type="message", id="msg_1"),
+        ),
+        NS(type="response.output_text.delta", delta="Hel", output_index=1),
+        NS(type="response.output_text.delta", delta="lo", output_index=1),
+        NS(
+            type="response.output_item.added",
+            output_index=2,
+            item=_function_call_item("call_1", "get_weather", ""),
+        ),
+        NS(
+            type="response.function_call_arguments.delta",
+            delta='{"city":',
+            output_index=2,
+        ),
+        NS(
+            type="response.function_call_arguments.delta",
+            delta=' "Paris"}',
+            output_index=2,
+        ),
+        NS(type="response.completed", response=final),
+    ]
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_stream_events_and_final_message(self):
+        final = _response(
+            [
+                _reasoning_item(text="thinking"),
+                _message_item("Hello"),
+                _function_call_item(),
+            ],
+            response_id="resp_s",
+            usage=_usage(input_tokens=50, output_tokens=10, reasoning=4),
+        )
+        agent, fake = _agent([_stream_events(final)])
+        chunks = [c async for c in agent.ask_stream_async("hi")]
+        assert fake.calls[0]["stream"] is True
+
+        assert [c["content"] for c in chunks if c["type"] == "thinking"] == [
+            "thin",
+            "king",
+        ]
+        assert [c["content"] for c in chunks if c["type"] == "text"] == ["Hel", "lo"]
+        started = [c for c in chunks if c["type"] == "tool_started"]
+        assert started == [
+            {"type": "tool_started", "name": "get_weather", "id": "call_1", "index": 2}
+        ]
+        deltas = [c["partial_json"] for c in chunks if c["type"] == "tool_delta"]
+        assert "".join(deltas) == '{"city": "Paris"}'
+        assert all(
+            c["name"] == "get_weather" for c in chunks if c["type"] == "tool_delta"
+        )
+
+        final_message = chunks[-1]["message"]
+        assert [p.type for p in final_message.parts] == [
+            "thinking",
+            "text",
+            "function_call",
+        ]
+        assert final_message.usage["reasoning_tokens"] == 4
+        # Usage arrives with the completed event, so compaction can see it.
+        assert agent.messages[-1].usage["input_tokens"] == 50
+
+    @pytest.mark.asyncio
+    async def test_stream_failure_raises(self):
+        failed = NS(id="r", output=[], usage=None, error=NS(message="boom"))
+        agent, fake = _agent([[NS(type="response.failed", response=failed)]])
+        with pytest.raises(RuntimeError, match="boom"):
+            [c async for c in agent.ask_stream_async("hi")]
+
+
+# ---------------------------------------------------------------------------
+# complete() / compaction
+# ---------------------------------------------------------------------------
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_complete_uses_instructions_and_max_output_tokens(self):
+        agent, fake = _agent([_response([_message_item("summary text")])])
+        text = await agent.provider.complete(
+            [{"role": "user", "content": "summarize"}],
+            system="You summarize.",
+            max_tokens=512,
+        )
+        assert text == "summary text"
+        call = fake.calls[0]
+        assert call["instructions"] == "You summarize."
+        assert call["max_output_tokens"] == 512
+        assert call["store"] is False
+        assert "max_tokens" not in call
+
+    @pytest.mark.asyncio
+    async def test_compaction_triggers_from_streamed_usage(self):
+        from agentlys.compaction import TokenThresholdCompaction
+
+        big = _response([_message_item("first")], usage=_usage(input_tokens=5000))
+        summary = _response([_message_item("the summary")])
+        after = _response([_message_item("second")])
+        agent, fake = _agent(
+            [_stream_events(big), summary, _stream_events(after)],
+            compaction=TokenThresholdCompaction(token_threshold=1000),
+        )
+        [c async for c in agent.ask_stream_async("one")]
+        chunks = [c async for c in agent.ask_stream_async("two")]
+        assert any(c["type"] == "compacting" for c in chunks)
+        assert agent.messages[0].has_compaction

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -187,7 +187,7 @@ class TestReasoningMapping:
         [
             (None, None),
             ({"type": "adaptive"}, None),
-            ({"type": "disabled"}, "low"),
+            ({"type": "disabled"}, None),
             ({"type": "enabled", "budget_tokens": 1024}, "low"),
             ({"type": "enabled", "budget_tokens": 5000}, "medium"),
             ({"type": "enabled", "budget_tokens": 16000}, "high"),
@@ -313,10 +313,7 @@ class TestSerialization:
             "summary": [{"type": "summary_text", "text": "plan"}],
             "encrypted_content": "ENC",
         }
-        assert items[1] == {
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": "Let me check."}],
-        }
+        assert items[1] == {"role": "assistant", "content": "Let me check."}
         assert items[2] == {
             "type": "function_call",
             "call_id": "call_1",
@@ -502,6 +499,9 @@ class TestToolLoop:
         tool = second["tools"][0]
         assert tool["type"] == "function" and tool["name"] == "get_weather"
         assert "defer_loading" not in tool
+        # The Responses API defaults strict to true, which rejects schemas
+        # with optional arguments.
+        assert tool["strict"] is False
 
     @pytest.mark.asyncio
     async def test_use_tools_only(self):
@@ -729,3 +729,71 @@ class TestComplete:
         chunks = [c async for c in agent.ask_stream_async("two")]
         assert any(c["type"] == "compacting" for c in chunks)
         assert agent.messages[0].has_compaction
+
+
+class TestReplayEdgeCases:
+    def test_trailing_reasoning_is_not_replayed(self):
+        # A turn cut off by max_output_tokens holds reasoning and nothing
+        # else; the API rejects a reasoning item without its following item.
+        message = Message(
+            role="assistant",
+            parts=[
+                MessagePart(
+                    type="thinking", thinking="t", thinking_signature="rs_1|ENC"
+                ),
+                MessagePart(type="text", content=""),
+            ],
+        )
+        message.is_live = True
+        assert message_to_responses_items(message) == []
+
+    def test_reasoning_without_id_is_skipped(self):
+        message = Message(
+            role="assistant",
+            parts=[
+                MessagePart(type="thinking", thinking="t", thinking_signature="|ENC"),
+                MessagePart(type="text", content="ok"),
+            ],
+        )
+        message.is_live = True
+        assert message_to_responses_items(message) == [
+            {"role": "assistant", "content": "ok"}
+        ]
+
+    def test_refusal_becomes_text(self):
+        item = NS(
+            type="message",
+            content=[NS(type="refusal", refusal="I can't help with that.")],
+        )
+        message = output_to_message([item])
+        assert message.content == "I can't help with that."
+
+    @pytest.mark.asyncio
+    async def test_stream_joins_summary_parts_like_the_stored_message(self):
+        final = _response([_reasoning_item(text="a\n\nb"), _message_item("x")])
+        events = [
+            NS(
+                type="response.output_item.added",
+                output_index=0,
+                item=NS(type="reasoning"),
+            ),
+            NS(type="response.reasoning_summary_part.added", output_index=0),
+            NS(type="response.reasoning_summary_text.delta", delta="a", output_index=0),
+            NS(type="response.reasoning_summary_part.added", output_index=0),
+            NS(type="response.reasoning_summary_text.delta", delta="b", output_index=0),
+            NS(type="response.completed", response=final),
+        ]
+        agent, fake = _agent([events])
+        chunks = [c async for c in agent.ask_stream_async("hi")]
+        streamed = "".join(c["content"] for c in chunks if c["type"] == "thinking")
+        assert streamed == chunks[-1]["message"].parts[0].thinking == "a\n\nb"
+
+    @pytest.mark.asyncio
+    async def test_incomplete_response_is_logged(self, caplog):
+        final = _response([_reasoning_item()])
+        final.status = "incomplete"
+        final.incomplete_details = NS(reason="max_output_tokens")
+        agent, fake = _agent([final])
+        with caplog.at_level("WARNING"):
+            await agent.ask_async("hi")
+        assert "max_output_tokens" in caplog.text

--- a/tests/test_openai_responses_live.py
+++ b/tests/test_openai_responses_live.py
@@ -1,0 +1,170 @@
+"""Live checks of the Responses provider against api.openai.com.
+
+Skipped unless OPENAI_LIVE=1 (needs a funded OPENAI_API_KEY). Uses the
+cheapest reasoning model at low effort: a full run costs well under a cent.
+"""
+
+import os
+
+import pytest
+from agentlys import Agentlys
+from agentlys.compaction import TokenThresholdCompaction
+from agentlys.model import Message
+from PIL import Image as PILImage
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("OPENAI_LIVE") != "1", reason="set OPENAI_LIVE=1 to hit the API"
+)
+
+MODEL = os.getenv("OPENAI_LIVE_MODEL", "gpt-5-nano")
+
+
+def _agent(**kwargs):
+    agent = Agentlys(
+        provider="openai_responses",
+        model=MODEL,
+        effort="low",
+        instruction="You are a terse assistant. Always use the tools you are given.",
+        **kwargs,
+    )
+    agent.provider.max_tokens = 1500
+    return agent
+
+
+def get_weather(city: str, unit: str = "C") -> str:
+    """Get the current weather for a city.
+
+    Args:
+        city: the city name
+        unit: temperature unit, C or F
+    """
+    return f"21 degrees {unit}, sunny in {city}"
+
+
+def render_chart(title: str) -> PILImage.Image:
+    """Render a chart and return it as an image.
+
+    Args:
+        title: chart title
+    """
+    image = PILImage.new("RGB", (8, 8), color=(200, 30, 30))
+    image.format = "PNG"
+    return image
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_replays_reasoning_and_optional_args():
+    agent = _agent()
+    agent.add_function(get_weather)  # optional arg -> strict must be false
+    messages = [
+        m async for m in agent.run_conversation_async("Weather in Paris, in C?")
+    ]
+    assistant_turns = [m for m in messages if m.role == "assistant"]
+    assert any(m.function_call_parts for m in assistant_turns)
+    assert "21" in messages[-1].content
+    # The first assistant turn carried a replayable reasoning item.
+    first = assistant_turns[0]
+    thinking = [p for p in first.parts if p.type == "thinking"]
+    assert thinking and thinking[0].thinking_signature.startswith("rs_")
+    assert "|" in thinking[0].thinking_signature
+    assert messages[-1].usage["output_tokens"] > 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_events_and_image_tool_result():
+    agent = _agent()
+    agent.add_function(render_chart)
+    events = [
+        e
+        async for e in agent.run_conversation_stream_async(
+            "Render a chart titled 'sales' then describe its main colour in one word."
+        )
+    ]
+    types = {e["type"] for e in events}
+    assert "tool_started" in types and "tool_delta" in types
+    assert "text" in types
+    final_text = "".join(e["content"] for e in events if e["type"] == "text")
+    assert final_text.strip()
+    # The image tool result went out as a content array and was accepted.
+    assert any(
+        m["message"].role == "function" and m["message"].image is not None
+        for m in events
+        if m["type"] == "function"
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_reload_with_keep_thinking():
+    agent = _agent()
+    agent.add_function(get_weather)
+    [m async for m in agent.run_conversation_async("Weather in Rome?")]
+    history = list(agent.messages)
+
+    fresh = _agent()
+    fresh.add_function(get_weather)
+    fresh.load_messages(history, keep_thinking=True)
+    answer = await fresh.ask_async("And the unit you used, in one word?")
+    assert answer.content
+
+
+@pytest.mark.asyncio
+async def test_compaction_and_complete():
+    agent = _agent(compaction=TokenThresholdCompaction(token_threshold=1))
+    await agent.ask_async("Say hi.")
+    chunks = [c async for c in agent.ask_stream_async("Say hi again.")]
+    assert any(c["type"] == "compacting" for c in chunks)
+    assert agent.messages[0].has_compaction
+
+
+@pytest.mark.asyncio
+async def test_tool_search_loads_deferred_tool():
+    agent = _agent()
+    agent.add_function(get_weather)
+    agent.add_function(render_chart)
+    agent.enable_tool_search()
+    messages = [
+        m
+        async for m in agent.run_conversation_async(
+            "Search your tools for a weather tool, then give me the weather in Oslo."
+        )
+    ]
+    called = [
+        p.function_call["name"]
+        for m in messages
+        if m.role == "assistant"
+        for p in m.function_call_parts
+    ]
+    assert "tool_search" in called and "get_weather" in called
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_provider_reasoning_effort():
+    agent = Agentlys(provider="openai", model=MODEL, effort="low")
+    agent.add_function(get_weather)
+    messages = [m async for m in agent.run_conversation_async("Weather in Lima?")]
+    assert "21" in messages[-1].content
+    assert messages[-1].usage["output_tokens"] > 0
+
+
+def test_sync_ask():
+    agent = _agent()
+    assert (
+        agent.ask("Reply with the single word pong.")
+        .content.strip()
+        .lower()
+        .startswith("pong")
+    )
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_history_from_other_provider_is_ignored():
+    agent = _agent()
+    agent.load_messages(
+        [
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="hello"),
+        ],
+        keep_thinking=True,
+    )
+    answer = await agent.ask_async("Reply with the single word pong.")
+    assert "pong" in answer.content.lower()


### PR DESCRIPTION
## Why

GPT-5 / o-series models could not run with reasoning: the OpenAI provider spoke Chat Completions only (no reasoning state across tool turns), `thinking=`/`effort=` either crashed or leaked into the request, `defer_loading` was sent as an unknown tool field, streamed responses carried no usage (compaction never fired) and `complete()` used `max_tokens`, rejected by reasoning models.

## What

- **New `openai_responses` provider** (Responses API): `reasoning: {effort, summary}`, encrypted reasoning round-tripped through the existing `thinking` MessagePart (`thinking_signature = "<rs_id>|<encrypted_content>"`, so callers that persist thinking blocks for Anthropic need no schema change), streaming `text` / `thinking` / `tool_started` / `tool_delta` events, usage with `cache_read_input_tokens` + `reasoning_tokens`, PDF documents, client-side deferred-tool emulation for tool search, `store=false`.
- **Chat Completions provider hardened**: `effort`/`thinking` → `reasoning_effort`, thinking/document parts serializable, `defer_loading` stripped (+ same emulation), `stream_options.include_usage`, `max_completion_tokens` in `complete()` (`AGENTLYS_OPENAI_LEGACY_MAX_TOKENS=1` opt-out), `reasoning_tokens` in usage.
- **Anthropic provider**: never replays an OpenAI-signed thinking block (a conversation switching providers no longer 400s).
- Docs: `docs/providers.md`.

## Decisions

- Effort mapping: OpenAI levels pass through, Anthropic `max` → `xhigh`; `thinking` `enabled` scales with `budget_tokens`, `adaptive`/`disabled` send nothing.
- `strict` is always explicit on Responses tools (the API defaults it to `true`, which rejects schemas with optional arguments).
- A trailing reasoning item (turn cut off by `max_output_tokens`) is never replayed; incomplete responses are logged.
- Client-side deferral kept over the SDK's native `defer_loading` + `tool_search` to keep agentlys' own search function.

## Verified live (see below)

The OpenAI key available during the work had no credit (`429 credit_balance_exhausted`), so the wire format is pinned by mocked tests only (408 passing). Before release, one live tool loop with reasoning replay + an image tool result + a tool with an optional argument should be run against `gpt-5.4`.

## Follow-ups

- `DefaultProvider` / `OpenAIProviderFunctionLegacy` still reject `effort=` / `cache_ttl=`.
- The app (myriade-private) and myriade-proxy PRs depend on this being released (app pin bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2cCP6UWMU1YkN8CMTCupR
## Live validation (2026-09-02, gpt-5-nano, effort low)

`OPENAI_LIVE=1 uv run pytest tests/test_openai_responses_live.py` → 8/8: tool loop with reasoning replay and an optional-argument tool, streaming with an image tool result, history reload with `keep_thinking=True`, compaction through `complete()`, tool search loading a deferred tool, the Chat Completions provider with `reasoning_effort`, sync `ask()`. Raw API probe confirmed: reasoning items replay with or without `id`, `function_call_output` accepts the content-array form, `xhigh`/`none` are rejected by nano (as designed, caller's choice).