### PR TITLE
fix(openai): re-ask malformed tool calls with bounded retries

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -22,7 +22,7 @@ from agentlys.providers.base_provider import (
     APIProvider,  # noqa: F401  (re-exported via agentlys.__init__)
     BaseProvider,
 )
-from agentlys.providers.utils import get_provider_and_model
+from agentlys.providers.utils import FunctionCallParsingError, get_provider_and_model
 from agentlys.utils import (
     csv_dumps,
     get_event_loop_or_create,
@@ -1232,6 +1232,17 @@ class Agentlys(AgentlysBase):
         args = part.function_call["arguments"]
         function_call_id = part.function_call_id
 
+        if part.arguments_parsing_error is not None:
+            raw = part.raw_arguments or ""
+            preview = raw[:500] + ("…" if len(raw) > 500 else "")
+            content = (
+                f"Invalid JSON arguments for {name}: {part.arguments_parsing_error}."
+                f"\nRaw arguments (first 500 characters): {preview}"
+                "\nThe tool was not executed. Re-emit the tool call with valid JSON "
+                "object arguments. Do not repeat other successful tool calls."
+            )
+            return (function_call_id, name, content, None)
+
         content = None
         image = None
 
@@ -1359,6 +1370,27 @@ class Agentlys(AgentlysBase):
                 )
                 yield (function_call_id, function_name, formatted_msg)
 
+    @staticmethod
+    def _check_parsing_retry_budget(response: Message, retries: int) -> int:
+        # Two re-asks per run; count failed turns, not parallel calls.
+        invalid = [
+            part
+            for part in response.function_call_parts
+            if part.arguments_parsing_error is not None
+        ]
+        if invalid:
+            if retries >= 2:
+                part = invalid[0]
+                raise FunctionCallParsingError(
+                    response.id,
+                    {
+                        "name": part.function_call["name"],
+                        "arguments": part.raw_arguments,
+                    },
+                )
+            return retries + 1
+        return retries
+
     async def run_conversation_async(
         self,
         question: typing.Union[str, Message, None] = None,
@@ -1374,6 +1406,7 @@ class Agentlys(AgentlysBase):
         else:
             message = question
 
+        parsing_retries = 0
         for _ in range(self.max_interactions):
             self._check_cancel()
             # Ask the LLM with the current message (if any)
@@ -1390,6 +1423,9 @@ class Agentlys(AgentlysBase):
                     return
             else:
                 yield response
+                parsing_retries = self._check_parsing_retry_budget(
+                    response, parsing_retries
+                )
 
                 try:
                     # Execute all tools in parallel
@@ -1466,6 +1502,7 @@ class Agentlys(AgentlysBase):
         else:
             message = question
 
+        parsing_retries = 0
         for _ in range(self.max_interactions):
             self._check_cancel()
             # Stream the LLM response
@@ -1493,6 +1530,10 @@ class Agentlys(AgentlysBase):
             else:
                 # Yield assistant message with all tool calls
                 yield {"type": "assistant", "message": response}
+
+                parsing_retries = self._check_parsing_retry_budget(
+                    response, parsing_retries
+                )
 
                 # Signal start of parallel execution
                 yield {

--- a/src/agentlys/model.py
+++ b/src/agentlys/model.py
@@ -117,6 +117,8 @@ class MessagePart:
         thinking_signature: typing.Optional[str] = None,
         is_redacted: bool = False,
         tool_references: typing.Optional[list[str]] = None,
+        raw_arguments: typing.Optional[str] = None,
+        arguments_parsing_error: typing.Optional[str] = None,
     ) -> None:
         self.type = type
         self.content = content
@@ -128,6 +130,8 @@ class MessagePart:
         self.thinking_signature = thinking_signature
         self.is_redacted = is_redacted
         self.tool_references = tool_references
+        self.raw_arguments = raw_arguments
+        self.arguments_parsing_error = arguments_parsing_error
 
 
 class Message:

--- a/src/agentlys/providers/openai.py
+++ b/src/agentlys/providers/openai.py
@@ -6,7 +6,6 @@ from agentlys.base import AgentlysBase
 from agentlys.model import Message, MessagePart
 from agentlys.providers.base_provider import BaseProvider
 from agentlys.providers.utils import (
-    FunctionCallParsingError,
     add_empty_function_result,
     drop_orphaned_function_results,
 )
@@ -160,6 +159,25 @@ def usage_to_dict(usage) -> typing.Optional[dict]:
     return result
 
 
+def function_call_part(name: str, raw_arguments: str, call_id: str) -> MessagePart:
+    """Preserve invalid arguments so the conversation can request a correction."""
+    error = None
+    try:
+        arguments = json.loads(raw_arguments or "{}")
+        if not isinstance(arguments, dict):
+            raise ValueError("Tool arguments must be a JSON object")
+    except ValueError as exc:
+        arguments = {}
+        error = str(exc)
+    return MessagePart(
+        type="function_call",
+        function_call={"name": name, "arguments": arguments},
+        function_call_id=call_id,
+        raw_arguments=raw_arguments if error else None,
+        arguments_parsing_error=error,
+    )
+
+
 def from_openai_object(
     role: str,
     content: str,
@@ -179,18 +197,9 @@ def from_openai_object(
                 "We don't support tool calls with type other than function"
             )
         function_call = tool_call.function
-        try:
-            arguments = json.loads(function_call.arguments or "{}")
-        except json.decoder.JSONDecodeError:
-            raise FunctionCallParsingError(id, function_call)
         parts.append(
-            MessagePart(
-                type="function_call",
-                function_call={
-                    "name": function_call.name,
-                    "arguments": arguments,
-                },
-                function_call_id=tool_call.id,
+            function_call_part(
+                function_call.name, function_call.arguments, tool_call.id
             )
         )
 
@@ -229,7 +238,11 @@ def parts_to_openai_dict(part: MessagePart) -> dict:
     elif part.type == "function_call":
         return {
             "name": part.function_call["name"],
-            "arguments": json.dumps(part.function_call["arguments"]),
+            "arguments": (
+                part.raw_arguments
+                if part.raw_arguments is not None
+                else json.dumps(part.function_call["arguments"])
+            ),
         }
     elif part.type == "function_result":
         return {
@@ -576,19 +589,8 @@ class OpenAIProvider(BaseProvider):
             parts.append(MessagePart(type="text", content=content))
         for index in sorted(tool_calls):
             entry = tool_calls[index]
-            try:
-                arguments = json.loads(entry["arguments"] or "{}")
-            except json.decoder.JSONDecodeError:
-                raise FunctionCallParsingError(response_id, entry)
             parts.append(
-                MessagePart(
-                    type="function_call",
-                    function_call={
-                        "name": entry["name"],
-                        "arguments": arguments,
-                    },
-                    function_call_id=entry["id"],
-                )
+                function_call_part(entry["name"], entry["arguments"], entry["id"])
             )
 
         final_message = Message(

--- a/tests/test_malformed_tool_calls.py
+++ b/tests/test_malformed_tool_calls.py
@@ -1,0 +1,160 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentlys import Agentlys
+from agentlys.model import Message
+from agentlys.providers.base_provider import APIProvider
+from agentlys.providers.openai import from_openai_object, message_to_openai_dict
+from agentlys.providers.utils import FunctionCallParsingError
+
+RAW = r"""{"text": "l\'outil"}"""
+
+
+def response(raw=RAW, call_id="call_bad"):
+    return from_openai_object(
+        "assistant",
+        None,
+        [
+            SimpleNamespace(
+                type="function",
+                id=call_id,
+                function=SimpleNamespace(name="save", arguments=raw),
+            )
+        ],
+        id="completion",
+        usage={"input_tokens": 10, "output_tokens": 5},
+    )
+
+
+@pytest.mark.parametrize("raw", [RAW, "{", "[]", "null"])
+def test_invalid_arguments_preserved(raw):
+    msg = response(raw)
+    part = msg.function_call_parts[0]
+    assert part.function_call["arguments"] == {}
+    assert part.arguments_parsing_error
+    assert part.raw_arguments == raw
+    assert msg.usage["output_tokens"] == 5
+    assert message_to_openai_dict(msg)["tool_calls"][0]["function"]["arguments"] == raw
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("exhaust", [False, True])
+async def test_reask_and_budget(stream, exhaust):
+    agent = Agentlys(provider=APIProvider.OPENAI, api_key="test")
+    saved = []
+
+    def save(text: str):
+        """Save text."""
+        saved.append(text)
+        return "saved"
+
+    agent.add_function(save)
+    replies = [response(), response()]
+    if exhaust:
+        replies.append(response())
+    else:
+        replies.extend(
+            [response('{"text": "correct"}'), Message(role="assistant", content="done")]
+        )
+    pending = iter(replies)
+
+    async def fetch(**kwargs):
+        return next(pending)
+
+    async def fetch_stream(**kwargs):
+        yield {"type": "message", "message": next(pending)}
+
+    async def run():
+        if stream:
+            return [item async for item in agent.run_conversation_stream_async("go")]
+        return [item async for item in agent.run_conversation_async("go")]
+
+    with (
+        patch.object(agent.provider, "fetch_async", side_effect=fetch),
+        patch.object(agent.provider, "fetch_stream_async", side_effect=fetch_stream),
+    ):
+        if exhaust:
+            with pytest.raises(FunctionCallParsingError):
+                await run()
+        else:
+            await run()
+
+    assert saved == ([] if exhaust else ["correct"])
+    failures = [
+        m
+        for m in agent.messages
+        if m.role == "function" and "Invalid JSON" in (m.content or "")
+    ]
+    assert len(failures) == 2
+    assert RAW in failures[0].content
+    assert "Re-emit" in failures[0].content
+    assert sum(m.usage["output_tokens"] for m in agent.messages if m.usage) == 15
+
+
+@pytest.mark.asyncio
+async def test_stream_provider_preserves_malformed_fragments_and_usage():
+    agent = Agentlys(provider=APIProvider.OPENAI, api_key="test")
+
+    async def chunks():
+        for fragment in [RAW[:12], RAW[12:]]:
+            yield SimpleNamespace(
+                id="completion",
+                usage=None,
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            role="assistant",
+                            content=None,
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=0,
+                                    id="call_bad",
+                                    function=SimpleNamespace(
+                                        name="save" if fragment == RAW[:12] else None,
+                                        arguments=fragment,
+                                    ),
+                                )
+                            ],
+                        )
+                    )
+                ],
+            )
+        yield SimpleNamespace(
+            id="completion",
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5),
+        )
+
+    with patch.object(
+        agent.provider.client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=chunks(),
+    ):
+        events = [event async for event in agent.provider.fetch_stream_async()]
+    msg = events[-1]["message"]
+    assert msg.function_call_parts[0].raw_arguments == RAW
+    assert msg.function_call_parts[0].arguments_parsing_error
+    assert msg.usage == {"input_tokens": 10, "output_tokens": 5}
+
+
+@pytest.mark.asyncio
+async def test_parallel_batch_skips_only_invalid_call():
+    agent = Agentlys(provider=APIProvider.OPENAI, api_key="test")
+    saved = []
+
+    def save(text: str):
+        """Save text."""
+        saved.append(text)
+        return "saved"
+
+    agent.add_function(save)
+    msg = response()
+    msg.parts.extend(response('{"text": "valid"}', "call_good").parts)
+    result = await agent._call_functions_parallel(msg.function_call_parts, msg)
+    assert saved == ["valid"]
+    assert {p.function_call_id for p in result.parts} == {"call_bad", "call_good"}
+    assert agent._check_parsing_retry_budget(msg, 0) == 1


### PR DESCRIPTION
Malformed JSON tool arguments from OpenAI-compatible Chat Completions APIs currently abort the conversation during parsing, before the assistant message and token usage can be retained. Preserve the raw arguments and parsing error on the function-call part, then return a tool result asking the model to emit valid JSON without executing the invalid call.

Allow two correction requests per conversation run, counting failed model turns rather than individual parallel calls. A third invalid response raises FunctionCallParsingError after its assistant message and usage have entered history. Apply the same behavior to streaming responses; include at most 500 characters of raw arguments in the correction message and replay the original arguments in OpenAI history. Valid sibling calls still execute while the retry budget remains available. No automatic JSON repair is applied.

Validation: 63 tests passed across malformed tool calls, OpenAI compatibility, parallel tools, and streaming. Coverage includes correction success, retry exhaustion, usage retention, malformed stream fragments, non-object JSON, and mixed valid/invalid parallel calls. Ruff and git diff --check passed. GLM behavior has not been benchmarked live.
