### PR TITLE
fix: one truncation marker the model can act on

### DIFF
--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -28,6 +28,7 @@ from agentlys.utils import (
     get_event_loop_or_create,
     inspect_schema,
     parse_chat_template,
+    truncate_with_marker,
 )
 
 if TYPE_CHECKING:
@@ -97,17 +98,6 @@ def _accepts_from_response(func) -> bool:
     except TypeError:
         pass
     return result
-
-
-def _truncate_with_warning(text: str, limit: int = OUTPUT_SIZE_LIMIT) -> str:
-    """Truncate text to limit and add warning if truncated."""
-    if len(text) > limit:
-        logging.warning(f"Output truncated from {len(text)} to {limit} characters")
-        return (
-            text[:limit]
-            + f"\n[Warning: Output truncated from {len(text)} to {limit} characters]"
-        )
-    return text
 
 
 class StopLoopException(Exception):
@@ -405,7 +395,7 @@ class Agentlys(AgentlysBase):
                 tool_output = tool.__llm__()
             else:
                 tool_output = (tool.__class__.__doc__ or "").strip()
-            tool_output = _truncate_with_warning(tool_output)
+            tool_output = truncate_with_marker(tool_output, OUTPUT_SIZE_LIMIT)
             tool_reprs.append(f"### {tool_name}\n{tool_output}")
         tool_context = "\n".join(tool_reprs)
 
@@ -1006,29 +996,16 @@ class Agentlys(AgentlysBase):
                         formatted_content.append(f"Added tool: {tool_id}")
                 formatted_content = "\n".join(formatted_content)
                 # Limit the size of the content
-                if len(formatted_content) > OUTPUT_SIZE_LIMIT:
-                    formatted_content = (
-                        formatted_content[:OUTPUT_SIZE_LIMIT]
-                        + f"\n... ({len(formatted_content)} characters)"
-                    )
+                formatted_content = truncate_with_marker(
+                    formatted_content, OUTPUT_SIZE_LIMIT
+                )
         elif isinstance(content, dict):
             # default=str: tool results routinely carry values json doesn't
             # know (Decimal, datetime, UUID, ...); stringify instead of crashing
             content_dump = json.dumps(content, default=str)
-            if len(content_dump) > OUTPUT_SIZE_LIMIT:
-                formatted_content = (
-                    content_dump[:OUTPUT_SIZE_LIMIT]
-                    + f"\n... ({len(content_dump)} characters)"
-                )
-            else:
-                formatted_content = content_dump
+            formatted_content = truncate_with_marker(content_dump, OUTPUT_SIZE_LIMIT)
         elif isinstance(content, str):
-            if len(content) > OUTPUT_SIZE_LIMIT:
-                formatted_content = (
-                    content[:OUTPUT_SIZE_LIMIT] + f"\n... ({len(content)} characters)"
-                )
-            else:
-                formatted_content = content
+            formatted_content = truncate_with_marker(content, OUTPUT_SIZE_LIMIT)
         elif isinstance(content, bytes):
             # Detect if it's an image
             try:

--- a/src/agentlys/chat.py
+++ b/src/agentlys/chat.py
@@ -395,7 +395,12 @@ class Agentlys(AgentlysBase):
                 tool_output = tool.__llm__()
             else:
                 tool_output = (tool.__class__.__doc__ or "").strip()
-            tool_output = truncate_with_marker(tool_output, OUTPUT_SIZE_LIMIT)
+            tool_output = truncate_with_marker(
+                tool_output,
+                OUTPUT_SIZE_LIMIT,
+                label=tool_name,
+                advice=" This tool's state is too large to show in full.",
+            )
             tool_reprs.append(f"### {tool_name}\n{tool_output}")
         tool_context = "\n".join(tool_reprs)
 
@@ -997,15 +1002,19 @@ class Agentlys(AgentlysBase):
                 formatted_content = "\n".join(formatted_content)
                 # Limit the size of the content
                 formatted_content = truncate_with_marker(
-                    formatted_content, OUTPUT_SIZE_LIMIT
+                    formatted_content, OUTPUT_SIZE_LIMIT, label=function_name
                 )
         elif isinstance(content, dict):
             # default=str: tool results routinely carry values json doesn't
             # know (Decimal, datetime, UUID, ...); stringify instead of crashing
             content_dump = json.dumps(content, default=str)
-            formatted_content = truncate_with_marker(content_dump, OUTPUT_SIZE_LIMIT)
+            formatted_content = truncate_with_marker(
+                content_dump, OUTPUT_SIZE_LIMIT, label=function_name
+            )
         elif isinstance(content, str):
-            formatted_content = truncate_with_marker(content, OUTPUT_SIZE_LIMIT)
+            formatted_content = truncate_with_marker(
+                content, OUTPUT_SIZE_LIMIT, label=function_name
+            )
         elif isinstance(content, bytes):
             # Detect if it's an image
             try:

--- a/src/agentlys/mcp.py
+++ b/src/agentlys/mcp.py
@@ -5,6 +5,8 @@ import typing
 
 from mcp import ClientSession
 
+from agentlys.utils import truncate_with_marker
+
 logger = logging.getLogger(__name__)
 
 # Anthropic and OpenAI both constrain tool names to this charset and length.
@@ -13,18 +15,6 @@ _TOOL_NAME_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_-]")
 
 # Filter signature: receives the MCP Tool object, returns True to expose it.
 ToolFilter = typing.Callable[[typing.Any], bool]
-
-
-def _truncate_result(
-    text: str, max_result_chars: typing.Optional[int], hint: str = ""
-) -> str:
-    """Truncate an MCP result to max_result_chars with an explicit marker."""
-    if max_result_chars is None or len(text) <= max_result_chars:
-        return text
-    return (
-        text[:max_result_chars]
-        + f"\n[... truncated to {max_result_chars} characters.{hint}]"
-    )
 
 
 def sanitize_tool_name(name: str, prefix: str = "") -> str:
@@ -68,11 +58,7 @@ def convert_tool_result(result, max_result_chars: typing.Optional[int] = None) -
     if not text:
         text = "(empty result)"
 
-    return _truncate_result(
-        text,
-        max_result_chars,
-        hint=" Refine the call (filters, pagination) to get less data.",
-    )
+    return truncate_with_marker(text, max_result_chars)
 
 
 async def fetch_mcp_server_tools(
@@ -202,7 +188,7 @@ async def fetch_mcp_server_resources(
                     else:
                         parts.append("[binary content omitted]")
                 text = "\n".join(parts) or "(empty result)"
-                return _truncate_result(text, max_result_chars)
+                return truncate_with_marker(text, max_result_chars)
 
             return read_resource
 

--- a/src/agentlys/utils.py
+++ b/src/agentlys/utils.py
@@ -2,6 +2,7 @@ import ast
 import asyncio
 import csv
 import inspect
+import logging
 import re
 import typing
 import warnings
@@ -14,6 +15,26 @@ from pydantic.json_schema import GenerateJsonSchema
 from pydantic_core import PydanticOmit
 
 from agentlys.model import Message
+
+
+def truncate_with_marker(text: str, limit: typing.Optional[int]) -> str:
+    """Cut ``text`` to ``limit`` and tell the model what it lost.
+
+    The marker is the model's only signal that a result is incomplete. It says
+    how much is missing and what to do about it, because retrying the same call
+    returns the same cut.
+    """
+    if limit is None or len(text) <= limit:
+        return text
+    total = len(text)
+    dropped_pct = round(100 * (total - limit) / total)
+    logging.warning("Tool output truncated from %d to %d characters", total, limit)
+    return (
+        text[:limit]
+        + f"\n[truncated: {limit} of {total} characters shown, {dropped_pct}% dropped."
+        " Narrow the call (filters, limit, pagination) — retrying it unchanged"
+        " returns the same cut.]"
+    )
 
 
 def limit_data_size(

--- a/src/agentlys/utils.py
+++ b/src/agentlys/utils.py
@@ -17,23 +17,54 @@ from pydantic_core import PydanticOmit
 from agentlys.model import Message
 
 
-def truncate_with_marker(text: str, limit: typing.Optional[int]) -> str:
+# Reads back the size a previous cut reported, so a second cut can still name
+# what the tool actually produced.
+_MARKER_ORIGINAL_RE = re.compile(r"\n\[truncated: \d+ of (\d+) characters shown,")
+_MARKER_TAIL_CHARS = 300
+
+NARROW_THE_CALL = (
+    " Narrow the call (filters, limit, pagination) — retrying it unchanged"
+    " returns the same cut."
+)
+
+
+def truncate_with_marker(
+    text: str,
+    limit: typing.Optional[int],
+    *,
+    label: str = "",
+    advice: str = NARROW_THE_CALL,
+) -> str:
     """Cut ``text`` to ``limit`` and tell the model what it lost.
 
     The marker is the model's only signal that a result is incomplete. It says
     how much is missing and what to do about it, because retrying the same call
     returns the same cut.
+
+    When ``text`` already carries a marker — an MCP result capped by its own
+    server budget before the chat loop sees it — the size reported is the one
+    that marker names, not the length of the intermediate string. Otherwise a
+    500 000-character result capped twice would be announced as 100 000, which
+    is a confident lie about how much the model is missing.
     """
     if limit is None or len(text) <= limit:
         return text
     total = len(text)
+    already_cut = _MARKER_ORIGINAL_RE.search(text[-_MARKER_TAIL_CHARS:])
+    if already_cut:
+        total = max(total, int(already_cut.group(1)))
     dropped_pct = round(100 * (total - limit) / total)
-    logging.warning("Tool output truncated from %d to %d characters", total, limit)
+    logging.warning(
+        "Tool output truncated from %d to %d characters%s",
+        total,
+        limit,
+        f" ({label})" if label else "",
+    )
     return (
         text[:limit]
         + f"\n[truncated: {limit} of {total} characters shown, {dropped_pct}% dropped."
-        " Narrow the call (filters, limit, pagination) — retrying it unchanged"
-        " returns the same cut.]"
+        + advice
+        + "]"
     )
 
 

--- a/tests/mcp_clients/test_mcp_fetch.py
+++ b/tests/mcp_clients/test_mcp_fetch.py
@@ -73,11 +73,13 @@ def test_convert_tool_result_error():
 
 
 def test_convert_tool_result_truncation():
+    """An MCP cut wears the same marker as every other cut in the library."""
     result = CallToolResult(content=[TextContent(type="text", text="x" * 500)])
     converted = convert_tool_result(result, max_result_chars=100)
     assert converted.startswith("x" * 100)
-    assert "truncated to 100 characters" in converted
-    assert len(converted) < 250
+    assert "[truncated: 100 of 500 characters shown, 80% dropped." in converted
+    assert "Narrow the call" in converted
+    assert len(converted) < 350
 
 
 @pytest.mark.asyncio
@@ -132,8 +134,8 @@ async def test_fetch_tools_result_cap():
     ) as session:
         functions, _ = await fetch_mcp_server_tools(session, max_result_chars=50)
         result = await functions["long_output"](n=5000)
-        assert "truncated to 50 characters" in result
-        assert len(result) < 200
+        assert "[truncated: 50 of 5000 characters shown, 99% dropped." in result
+        assert len(result) < 250
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_result_formatting.py
+++ b/tests/test_tool_result_formatting.py
@@ -165,3 +165,19 @@ async def test_an_oversized_result_says_how_much_it_lost(function):
 async def test_a_result_that_fits_carries_no_marker():
     result = await _run_single_tool(get_price, "call_small")
     assert "[truncated: " not in result.parts[0].content
+
+
+@pytest.mark.asyncio
+async def test_a_second_cut_still_names_the_size_the_tool_produced():
+    """An MCP result is capped by its server budget before the loop sees it.
+
+    Reporting the intermediate length would tell the model 80% was dropped
+    when 96% was — a confident lie about what it is missing.
+    """
+    from agentlys.utils import truncate_with_marker
+
+    once = truncate_with_marker("D" * 500_000, 100_000)
+    twice = truncate_with_marker(once, OUTPUT_SIZE_LIMIT)
+
+    assert f"[truncated: {OUTPUT_SIZE_LIMIT} of 500000 characters shown" in twice
+    assert "96% dropped" in twice

--- a/tests/test_tool_result_formatting.py
+++ b/tests/test_tool_result_formatting.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 
 import pytest
 from agentlys import Agentlys
+from agentlys.chat import OUTPUT_SIZE_LIMIT
 from agentlys.model import Message, MessagePart
 
 
@@ -119,3 +120,48 @@ async def test_formatting_error_becomes_function_result_in_stream():
     assert message.parts[0].type == "function_result"
     assert message.parts[0].function_call_id == "call_bytes_stream"
     assert "ValueError" in message.parts[0].content
+
+
+# A cut the model cannot see is a cut it cannot work around: these pin the one
+# marker every truncating path now shares.
+
+OVERFLOW = OUTPUT_SIZE_LIMIT + 30_000
+
+
+def get_long_text() -> str:
+    """Return a string well past the output limit."""
+    return "x" * OVERFLOW
+
+
+def get_long_dict() -> dict:
+    """Return a dict whose serialization is well past the output limit."""
+    return {"rows": ["y" * 100 for _ in range(OVERFLOW // 100)]}
+
+
+def get_long_string_list() -> list:
+    """Return a list of strings well past the output limit."""
+    return ["z" * 1000 for _ in range(OVERFLOW // 1000)]
+
+
+@pytest.mark.parametrize(
+    "function", [get_long_text, get_long_dict, get_long_string_list]
+)
+@pytest.mark.asyncio
+async def test_an_oversized_result_says_how_much_it_lost(function):
+    result = await _run_single_tool(function, f"call_{function.__name__}")
+    content = result.parts[0].content
+
+    assert "[truncated: " in content
+    assert f"{OUTPUT_SIZE_LIMIT} of " in content
+    assert "% dropped" in content
+    # The advice matters more than the number: retrying returns the same cut.
+    assert "Narrow the call" in content
+    # The body itself is still bounded by the limit.
+    marker_start = content.index("\n[truncated: ")
+    assert marker_start == OUTPUT_SIZE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_a_result_that_fits_carries_no_marker():
+    result = await _run_single_tool(get_price, "call_small")
+    assert "[truncated: " not in result.parts[0].content


### PR DESCRIPTION
## The problem

Five code paths cut a tool result. Four of them ended with `... (N characters)` — a footnote that never says the result is incomplete, let alone what to do about it.

| Path | Marker |
|---|---|
| `list[dict]` → CSV | `... N of M rows displayed.` — the only usable one |
| `dict` | `... (150000 characters)` |
| `str` | `... (N characters)` |
| `list[str]` | `... (N characters)` |
| `__llm__` tool state | `[Warning: Output truncated from N to M characters]` |
| `mcp.py` | `[... truncated to N characters. Refine the call…]` |

Three wordings for one concept, and the two clear ones sit on the paths that matter least.

Downstream, an agent reasoned on a third of a listing without knowing it, then retried the identical call and got the identical cut.

## What changes

One helper, `utils.truncate_with_marker`, used by every path. Each cut says how much was shown, how much existed, the share dropped, and that narrowing the call — not retrying it — is the way out:

```
[truncated: 20000 of 500000 characters shown, 96% dropped. Narrow the call
(filters, limit, pagination) — retrying it unchanged returns the same cut.]
```

The CSV path is untouched: dropping rows and saying `N of M rows displayed` is already the right behaviour there.

The warning now carries the tool name, so a truncation in the logs says which tool overflowed. And the `__llm__` tool-state path drops the "Narrow the call" advice, which is meaningless in a system prompt where there is no call to narrow.

## Composed truncation: the marker must not lie

An MCP result is capped by its own server budget before the chat loop sees it, then capped again at `OUTPUT_SIZE_LIMIT`. Reporting the length of that intermediate string announced `20000 of 100152, 80% dropped` for a result the tool had produced at 500 000 characters — 96% dropped.

That is worse than the vague footnote it replaced: a precise, confident, false number. So the helper reads back the size a previous marker names and reports that. Pinned by a test.

This is what the MCP path actually gains here. The server-side marker at byte 100 000 was never going to reach the model — the second cut is upstream of it — so the fix is an honest total, not a rescued hint.

## Tests

No test covered a truncated `str`, `dict` or `list[str]` result. Four new ones do, via the existing offline harness in `test_tool_result_formatting.py`, plus a case pinning that a result which fits carries no marker, plus the composed-cut case above. The two MCP assertions move to the shared wording.

Full suite: 33 failures before and after, an identical set, all from a missing `OPENAI_API_KEY` in this environment. No regression.

## Consumers to update at the pin bump

`service/evals/bench/search_cost.py` decides truncation solely by regex on the old marker (`TRUNCATION_RE`, `TRUNCATED_CHARS = 20_023`). It must learn both markers — the old one for historical dumps, the new one going forward — or its `truncated_results` silently reads zero for ever.

## Not in this PR

Keeping the *tail* where the verdict lives at the end. On review that reduces to one case, not three: an exception agentlys formats itself, whose last line is the exception by construction. An MCP result is third-party data whose tail is worth no more than its head, and a sub-agent's reply is prose bounded better at its source by the caller's own instruction.