### PR TITLE
fix(compaction): summarize images by placeholder, not base64

### DIFF
--- a/src/agentlys/compaction.py
+++ b/src/agentlys/compaction.py
@@ -122,7 +122,7 @@ class TokenThresholdCompaction:
         for msg in messages:
             if not msg.parts:
                 continue
-            conversation_text.append(msg.to_markdown())
+            conversation_text.append(msg.to_markdown(inline_images=False))
         conversation_str = "\n".join(conversation_text)
 
         prompt = self.instructions or DEFAULT_COMPACTION_PROMPT

--- a/src/agentlys/model.py
+++ b/src/agentlys/model.py
@@ -457,7 +457,21 @@ class Message:
             text += f"{part.type}, "
         return text[:-2] + "])"
 
-    def to_markdown(self) -> str:
+    def to_markdown(self, inline_images: bool = True) -> str:
+        """Render the message as markdown.
+
+        ``inline_images=False`` replaces image data with a placeholder: a
+        base64 PNG costs tens of thousands of tokens as text, so a consumer
+        that only needs the prose (the compaction summarizer) must not get
+        the bytes — a chart-heavy history rendered inline overflowed the
+        summary model's context and the compaction itself failed.
+        """
+
+        def image_md(image: Image) -> str:
+            if not inline_images:
+                return "[image omitted]"
+            return f"![Image](data:image/png;base64,{image.to_base64()})"
+
         text = f"## {self.role}\n"
         for part in self.parts:
             if part.type == "text":
@@ -467,11 +481,11 @@ class Message:
             elif part.type == "function_result":
                 text += f"> Result: {part.content}\n"
             elif part.type == "function_result_image":
-                image_data_url = f"data:image/png;base64,{part.image.to_base64()}"
-                text += f"> Result image: ![Image]({image_data_url})\n"
+                if part.content:
+                    text += f"> Result: {part.content}\n"
+                text += f"> Result image: {image_md(part.image)}\n"
             elif part.type == "image":
-                image_data_url = f"data:image/png;base64,{part.image.to_base64()}"
-                text += f"> Image: ![Image]({image_data_url})\n"
+                text += f"> Image: {image_md(part.image)}\n"
             elif part.type == "document":
                 doc_name = part.document.name if part.document else "document"
                 doc_type = part.document.media_type if part.document else "unknown"

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -76,6 +76,31 @@ class TestCompactionRendering(unittest.TestCase):
         self.assertIn("Earlier discussion summary", md)
         self.assertIn("New question here", md)
 
+    def test_to_markdown_can_omit_image_data(self):
+        from PIL import Image as PILImage
+
+        png = PILImage.new("RGB", (8, 8))
+        png.format = "PNG"
+        msg = Message(
+            role="function",
+            parts=[
+                MessagePart(
+                    type="function_result_image",
+                    content="ok",
+                    function_call_id="c1",
+                    image=png,
+                ),
+                MessagePart(type="image", image=png),
+            ],
+        )
+        self.assertIn("data:image/png;base64,", msg.to_markdown())
+        md = msg.to_markdown(inline_images=False)
+        self.assertNotIn("base64", md)
+        self.assertEqual(
+            md,
+            "## function\n> Result: ok\n> Result image: [image omitted]\n> Image: [image omitted]\n",
+        )
+
     def test_to_terminal_includes_compaction(self):
         msg = Message(
             role="user",
@@ -363,6 +388,68 @@ class TestTokenThresholdCompactionCompact(unittest.TestCase):
         self.assertEqual(
             agent.messages[0].parts[0].content, "Conversation summary here"
         )
+
+    def test_compact_does_not_inline_images_in_summary_prompt(self):
+        """Images are described, never base64-inlined, in the summary request.
+
+        A chart-heavy conversation rendered with inline data URLs blew past
+        the summary model's context (2.1M tokens for a 130k-token history),
+        so compaction — the thing meant to free context — failed the turn.
+        """
+        from PIL import Image as PILImage
+
+        compaction = TokenThresholdCompaction()
+        agent = Agentlys(
+            instruction="Test", provider=APIProvider.ANTHROPIC, compaction=compaction
+        )
+        png = PILImage.new("RGB", (64, 64), color="white")
+        png.format = "PNG"
+        agent.messages = [
+            Message(role="user", content="Plot it"),
+            Message(
+                role="assistant",
+                parts=[
+                    MessagePart(
+                        type="function_call",
+                        function_call={"name": "plot", "arguments": {}},
+                        function_call_id="c1",
+                    )
+                ],
+            ),
+            Message(
+                role="function",
+                parts=[
+                    MessagePart(
+                        type="function_result_image",
+                        content='{"chart_id": "abc"}',
+                        function_call_id="c1",
+                        image=png,
+                    )
+                ],
+            ),
+            Message(role="user", parts=[MessagePart(type="image", image=png)]),
+        ]
+
+        mock_text_block = MagicMock()
+        mock_text_block.type = "text"
+        mock_text_block.text = "summary"
+        mock_response = MagicMock()
+        mock_response.content = [mock_text_block]
+        agent.provider.client = MagicMock()
+        agent.provider.client.messages.create = AsyncMock(return_value=mock_response)
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(compaction.compact(agent))
+        finally:
+            loop.close()
+
+        prompt = agent.provider.client.messages.create.call_args.kwargs["messages"][0][
+            "content"
+        ]
+        self.assertNotIn("base64", prompt)
+        self.assertIn('{"chart_id": "abc"}', prompt)
+        self.assertIn("[image omitted]", prompt)
 
     def test_compact_preserves_document_attachments(self):
         """Documents survive compaction: the text history is summarized but

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -93,9 +93,16 @@ class TestCompactionRendering(unittest.TestCase):
                 MessagePart(type="image", image=png),
             ],
         )
-        self.assertIn("data:image/png;base64,", msg.to_markdown())
-        md = msg.to_markdown(inline_images=False)
-        self.assertNotIn("base64", md)
+        inline = msg.to_markdown()
+        self.assertIn("data:image/png;base64,", inline)
+        self.assertIn("> Result: ok\n", inline)
+
+        # Omitting must not even attempt the encoding: that is the cost
+        # being avoided, not just the bytes in the output.
+        with patch.object(
+            type(msg.parts[0].image), "to_base64", side_effect=AssertionError
+        ):
+            md = msg.to_markdown(inline_images=False)
         self.assertEqual(
             md,
             "## function\n> Result: ok\n> Result image: [image omitted]\n> Image: [image omitted]\n",


### PR DESCRIPTION
## Problem

`TokenThresholdCompaction.compact()` renders the whole history with `Message.to_markdown()`, which inlines every `image` / `function_result_image` as a base64 data URL. A PNG is tens of thousands of tokens of text the summarizer cannot use.

Production case (Myriade, 2026-09-11): a cockpit conversation with many chart renders hit the 130k threshold; the summary request weighed **2,113,402 tokens** and was refused with `prompt is too long: 2113402 tokens > 1000000 maximum`. The compaction meant to free context killed the turn, and the UI reported "Context is full".

## Change

- `Message.to_markdown(inline_images: bool = True)` — with `False`, images render as `[image omitted]` instead of the data URL. Default unchanged for other callers.
- `TokenThresholdCompaction.compact()` renders with `inline_images=False`.
- The text a tool returned alongside its image (e.g. `{"chart_id": ...}`) is now rendered as `> Result: …` before the image line, in both modes — it was dropped before, so the summary could not keep the reference.

## Tests

- `to_markdown(inline_images=False)` rendering.
- `compact()` sends a summary prompt with no base64 and with the image's text result.

`tests/test_compaction.py`: 36 passed. Full suite: same 33 pre-existing failures as master (missing `OPENAI_API_KEY` locally), +2 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRYJ9sE31SG25cJSfK2Av9